### PR TITLE
Update dependencies to version 15.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-git</artifactId>
 	<packaging>jar</packaging>
 	<name>Git Data Store</name>
-	<version>15.2.1-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-git.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-git.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary

This PR updates the project version and dependencies to align with the latest Fess 15.3.0 release.

## Changes Made

- Update project version from `15.2.1-SNAPSHOT` to `15.3.0-SNAPSHOT`
- Update parent dependency `fess-parent` from `15.2.0` to `15.3.0`

## Testing

- Maven build verification recommended
- No functional changes expected as this is a dependency version update

## Additional Notes

This change maintains compatibility with the Fess framework version 15.3.0 and should be merged to keep the plugin in sync with the parent project release cycle.