### PR TITLE
chore(deps): update fess-parent version to 15.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.5.0-SNAPSHOT</version>
+		<version>15.5.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary
Update the fess-parent POM version from 15.5.0-SNAPSHOT to the 15.5.0 release version.

## Changes Made
- Updated `fess-parent` version in `pom.xml` from `15.5.0-SNAPSHOT` to `15.5.0`

## Testing
- Standard Maven build should verify dependency resolution

## Breaking Changes
- None

## Additional Notes
- This aligns the project with the released fess-parent 15.5.0 artifact