### PR TITLE
fix: resolve Javadoc warnings

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
@@ -522,6 +522,7 @@ public class GitDataStore extends AbstractDataStore {
      * @param path The path.
      * @return The revision commit.
      * @throws GitAPIException If an error occurs while accessing the Git repository.
+     * @throws IOException If an I/O error occurs while reading the Git repository.
      */
     protected RevCommit getRevCommit(final Map<String, Object> configMap, final String path) throws GitAPIException, IOException {
         final Git git = (Git) configMap.get(GIT);


### PR DESCRIPTION
Fixes 1 Javadoc warning reported by `mvn clean javadoc:javadoc`.

## Change
- `GitDataStore.getRevCommit` declares `throws GitAPIException, IOException` but its Javadoc only documented `@throws GitAPIException`. Added the missing `@throws IOException` tag.

## Verification
`mvn clean javadoc:javadoc` now produces BUILD SUCCESS with zero `warning:` and zero `error:` lines from the javadoc tool.