### PR TITLE
fix: prevent data loss and repeated-crawl failures in GitDataStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ prev_commit_id=
 # prunes files removed/renamed upstream. Setting it to "false" disables that cleanup, which is safer while
 # testing a new configuration (or, e.g., during a fail-fast error triggered by the new fetch/checkout
 # error paths in this plugin) since a failed/aborted run will not wipe out the previously-indexed documents.
+# Note: this plugin's fail-fast checks only stop ITS OWN per-file deletes; Fess's crawling infrastructure
+# runs deleteOldDocs() unconditionally after every crawl attempt (success or failure) unless this is
+# "false", so "false" is required, not just safer, for a failed/aborted run to leave previously-indexed
+# documents intact.
 delete_old_docs=false
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ uri=https://github.com/codelibs/fess-ds-git.git
 base_url=https://github.com/codelibs/fess/blob/master/
 extractors=text/.*:textExtractor,application/xml:textExtractor,application/javascript:textExtractor,
 prev_commit_id=
-delete_old_docs=false
 ```
 
 Script:
@@ -43,4 +42,17 @@ content_length=contentLength
 last_modified=timestamp
 mimetype=mimetype
 ```
+
+### Persistent Repository (`repository_path`)
+
+By default the crawler clones into a fresh temporary directory on every run and deletes it afterwards.
+Set `repository_path` to a persistent directory to keep the local clone between runs:
+
+```
+repository_path=/var/lib/fess/git/fess-ds-git
+```
+
+With a persistent path, each run only fetches new commits instead of cloning from scratch, which makes
+repeated/incremental crawls of large repositories considerably faster. The trade-off is disk usage: the
+clone (all fetched branches and their history) stays on disk between runs.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ uri=https://github.com/codelibs/fess-ds-git.git
 base_url=https://github.com/codelibs/fess/blob/master/
 extractors=text/.*:textExtractor,application/xml:textExtractor,application/javascript:textExtractor,
 prev_commit_id=
+# delete_old_docs is a framework-level parameter handled by Fess's crawling infrastructure (DataIndexHelper),
+# not specific to this plugin. When it is not "false", documents from a previous crawl of this DataConfig
+# that were not re-indexed in the current session are deleted after the crawl finishes -- this is what
+# prunes files removed/renamed upstream. Setting it to "false" disables that cleanup, which is safer while
+# testing a new configuration (or, e.g., during a fail-fast error triggered by the new fetch/checkout
+# error paths in this plugin) since a failed/aborted run will not wipe out the previously-indexed documents.
+delete_old_docs=false
 ```
 
 Script:
@@ -43,6 +50,12 @@ last_modified=timestamp
 mimetype=mimetype
 ```
 
+Note: the `username`/`password` parameters (used only for Git authentication) are intentionally excluded
+from the script-evaluation context, so they cannot be referenced from the `Script` mapping above (e.g.
+`digest=username` will evaluate to `null`). This is a security fix -- previously they were available to
+custom scripts and could be inadvertently indexed. Scripts that relied on `username`/`password` fields need
+to be updated to no longer reference them.
+
 ### Persistent Repository (`repository_path`)
 
 By default the crawler clones into a fresh temporary directory on every run and deletes it afterwards.
@@ -55,4 +68,17 @@ repository_path=/var/lib/fess/git/fess-ds-git
 With a persistent path, each run only fetches new commits instead of cloning from scratch, which makes
 repeated/incremental crawls of large repositories considerably faster. The trade-off is disk usage: the
 clone (all fetched branches and their history) stays on disk between runs.
+
+Caveats:
+
+- The advisory lock that protects `repository_path` across overlapping crawls is implemented with
+  `FileChannel.tryLock()`, an OS-level file lock. Its behavior on network filesystems (NFS/SMB/etc.) is
+  filesystem- and OS-dependent and is not guaranteed to provide exclusion across different hosts. For
+  multi-node deployments, prefer local disk for `repository_path`, or independently verify file-locking
+  semantics on your target filesystem before relying on it.
+- Stale-lock cleanup assumes this plugin's own advisory lock is the only coordination mechanism for the
+  directory. Do not point `repository_path` at a directory that other tools (a manual `git gc`/`git fsck`,
+  backup scripts, etc.) might also operate on concurrently: once the lock is held, cleanup deletes any
+  `*.lock` file found under `.git`, regardless of who created it.
+- Windows file-lock and file-deletion semantics for this feature have not been specifically verified.
 

--- a/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
@@ -159,6 +159,13 @@ public class GitDataStore extends AbstractDataStore {
     /** Parameter key for the repository path. */
     protected static final String REPOSITORY_PATH = "repository_path";
 
+    /**
+     * Parameter key for Fess's framework-level "delete old documents" behavior. This is handled by Fess's
+     * crawling infrastructure ({@code DataIndexHelper}), not by this plugin; it is read here only to warn when
+     * a persistent {@link #REPOSITORY_PATH} is used without disabling it (see {@link #storeData}).
+     */
+    protected static final String DELETE_OLD_DOCS = "delete_old_docs";
+
     /** File name of the advisory lock marker placed next to a persistent {@code repository_path}. */
     protected static final String LOCK_FILE_NAME = ".fess-ds-git.lock";
 
@@ -209,6 +216,18 @@ public class GitDataStore extends AbstractDataStore {
             logger.warn("base_url is blank: indexed document URLs will be empty and delete/rename tracking will be skipped.");
         }
 
+        // A persistent repository_path exists to preserve state across runs, but the fail-fast checks this
+        // plugin adds (unresolvable commit_id, lock contention, etc.) only stop ITS OWN per-file deletes:
+        // Fess's crawling infrastructure still runs deleteOldDocs() after every crawl attempt -- success OR
+        // failure -- unless delete_old_docs=false. So a failed/aborted run would otherwise prune every
+        // previously-indexed document of this DataConfig. Warn so the "required, not just safer" constraint is
+        // visible at runtime, not just in the README.
+        if (StringUtil.isNotBlank(repositoryPath) && !Constants.FALSE.equals(paramMap.getAsString(DELETE_OLD_DOCS))) {
+            logger.warn("repository_path is set but delete_old_docs is not 'false': a failed or aborted crawl will let Fess "
+                    + "prune all previously-indexed documents for this DataConfig. Set delete_old_docs=false to keep the "
+                    + "existing index intact across failed/aborted runs.");
+        }
+
         // getUrlFilter()/logger.info() only depend on paramMap/uri (not on configMap/the lock below), so they
         // are deliberately resolved BEFORE the lock is acquired: getUrlFilter() can throw (e.g.
         // ComponentNotFoundException, or CrawlerSystemException from UrlFilterImpl#init), and if that
@@ -240,6 +259,11 @@ public class GitDataStore extends AbstractDataStore {
         } catch (final Exception e) {
             releaseRepositoryLock(lockHolder);
             throw new DataStoreException("Failed to initialize Git repository " + redactUrl(uri), e);
+        } catch (final Error e) {
+            // An Error (e.g. NoClassDefFoundError) raised after the advisory lock was acquired must not leak
+            // it; release the lock and rethrow the Error unchanged so it still propagates.
+            releaseRepositoryLock(lockHolder);
+            throw e;
         }
         configMap.putAll(lockHolder);
         configMap.put(URI, uri);
@@ -377,7 +401,10 @@ public class GitDataStore extends AbstractDataStore {
         final String paramStr = buildHandlerParameter(dataConfig.getHandlerParameterMap(), toCommitId.name(), sourceRef);
         dataConfig.setHandlerParameter(paramStr);
         if (logger.isDebugEnabled()) {
-            logger.debug("Updating data config by {}.", paramStr);
+            // Do NOT log paramStr: it is the full handlerParameter string and carries the cleartext password
+            // and the raw uri userinfo. Log only non-sensitive identifiers; sourceRef is already redacted
+            // (it is the currentSourceRef built with redactUrl(uri) in storeData).
+            logger.debug("Updating data config {} to commit {} (source_ref={}).", dataConfig.getId(), toCommitId.name(), sourceRef);
         }
         ComponentUtil.getComponent(DataConfigBhv.class).update(dataConfig);
         logger.info("Updated DataConfig: {}", dataConfig.getId());
@@ -584,7 +611,17 @@ public class GitDataStore extends AbstractDataStore {
         }
         configMap.put(REPOSITORY_LOCK_CHANNEL, channel);
         configMap.put(REPOSITORY_LOCK, lock);
-        deleteStaleLockFiles(new File(repositoryPath, ".git"));
+        try {
+            deleteStaleLockFiles(new File(repositoryPath, ".git"));
+        } catch (final RuntimeException | Error e) {
+            // deleteStaleLockFiles already catches the IOException/UncheckedIOException that Files.walk can
+            // throw; any OTHER throwable (e.g. a SecurityException under a SecurityManager) would otherwise
+            // escape before the lock is merged into the caller's finally-guarded configMap, leaking the lock
+            // (and its channel) for the life of the JVM -- exactly the permanent crawl-blocking DoS this
+            // locking exists to prevent. Release on any throw and rethrow.
+            releaseRepositoryLock(configMap);
+            throw e;
+        }
     }
 
     /**
@@ -907,7 +944,13 @@ public class GitDataStore extends AbstractDataStore {
                 crawlerStatsHelper.record(statsKey, StatsAction.PREPARED);
 
                 if (logger.isDebugEnabled()) {
-                    logger.debug("resultMap: {}", resultMap);
+                    // resultMap holds the raw DataConfig under "crawlingConfig"; DataConfig.toString() emits the
+                    // un-redacted handlerParameter (uri userinfo, and a cleartext password after a write-back), so
+                    // log a copy without it -- the other credential-bearing entries (username/password/uri) were
+                    // already removed/redacted above.
+                    final Map<String, Object> logMap = new LinkedHashMap<>(resultMap);
+                    logMap.remove("crawlingConfig");
+                    logger.debug("resultMap: {}", logMap);
                 }
 
                 final String scriptType = getScriptType(paramMap);

--- a/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
@@ -20,8 +20,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -30,7 +36,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.output.DeferredFileOutputStream;
@@ -68,8 +73,10 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectStream;
 import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.RefUpdate;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.FetchResult;
@@ -141,11 +148,23 @@ public class GitDataStore extends AbstractDataStore {
     /** Parameter key for the previous commit ID. */
     protected static final String PREV_COMMIT_ID = "prev_commit_id";
 
+    /** Parameter key for the previous source ref (uri + resolved commit ref) used to detect a changed source configuration. */
+    protected static final String PREV_SOURCE_REF = "prev_source_ref";
+
     /** Parameter key for the temporary repository path. */
     protected static final String TEMP_REPOSITORY_PATH = "temp_repository_path";
 
     /** Parameter key for the repository path. */
     protected static final String REPOSITORY_PATH = "repository_path";
+
+    /** File name of the advisory lock marker placed next to a persistent {@code repository_path}. */
+    protected static final String LOCK_FILE_NAME = ".fess-ds-git.lock";
+
+    /** Configuration map key for the repository lock channel. */
+    protected static final String REPOSITORY_LOCK_CHANNEL = "repository_lock_channel";
+
+    /** Configuration map key for the repository lock. */
+    protected static final String REPOSITORY_LOCK = "repository_lock";
 
     /** Parameter key for the max size. */
     protected static final String MAX_SIZE = "max_size";
@@ -176,10 +195,16 @@ public class GitDataStore extends AbstractDataStore {
         final String username = paramMap.getAsString(USERNAME);
         final String password = paramMap.getAsString(PASSWORD);
         final String prevCommit = paramMap.getAsString(PREV_COMMIT_ID);
+        final String prevSourceRef = paramMap.getAsString(PREV_SOURCE_REF);
         final String baseUrl = paramMap.getAsString(BASE_URL);
+        final String repositoryPath = paramMap.getAsString(REPOSITORY_PATH);
         CredentialsProvider credentialsProvider = null;
         if (username != null && password != null) {
             credentialsProvider = new UsernamePasswordCredentialsProvider(username, password);
+        }
+
+        if (StringUtil.isBlank(baseUrl)) {
+            logger.warn("base_url is blank: indexed document URLs will be empty and delete/rename tracking will be skipped.");
         }
 
         final Map<String, Object> configMap = createConfigMap(paramMap);
@@ -187,11 +212,14 @@ public class GitDataStore extends AbstractDataStore {
 
         final UrlFilter urlFilter = getUrlFilter(paramMap);
 
-        logger.info("Git: {}", uri);
+        logger.info("Git: {}", redactUrl(uri));
 
         final Repository repository = (Repository) configMap.get(REPOSITORY);
         try (final Git git = new Git(repository)) {
             configMap.put(GIT, git);
+            if (StringUtil.isNotBlank(repositoryPath)) {
+                lockRepositoryPath(new File(repositoryPath), configMap);
+            }
             final FetchResult fetchResult = git.fetch()
                     .setForceUpdate(true)
                     .setRemote(uri)
@@ -202,19 +230,25 @@ public class GitDataStore extends AbstractDataStore {
             if (logger.isDebugEnabled()) {
                 logger.debug("Fetch Result: {}", fetchResult.getMessages());
             }
+            final String resolvedCommitId = resolveDefaultBranch(repository, fetchResult, commitId);
             if (!hasCommitLogs(configMap)) {
-                final Ref ref = git.checkout().setName(commitId).call();
+                final Ref ref = git.checkout().setName(resolvedCommitId).call();
                 if (logger.isDebugEnabled()) {
                     logger.debug("Checked out {}", ref.getName());
                 }
             }
+            final String currentSourceRef = redactUrl(uri) + "#" + resolvedCommitId;
             final ObjectId fromCommitId;
-            if (StringUtil.isNotBlank(prevCommit)) {
+            if (StringUtil.isNotBlank(prevCommit) && isSameSource(prevSourceRef, currentSourceRef)) {
                 fromCommitId = repository.resolve(prevCommit);
             } else {
+                if (StringUtil.isNotBlank(prevCommit) && StringUtil.isNotBlank(prevSourceRef)) {
+                    logger.info("Source configuration changed ('{}' -> '{}'); performing a full reindex instead of an incremental diff.",
+                            prevSourceRef, currentSourceRef);
+                }
                 fromCommitId = null;
             }
-            final ObjectId toCommitId = repository.resolve(commitId);
+            final ObjectId toCommitId = resolveToCommitId(repository, commitId, resolvedCommitId);
             configMap.put(CURRENT_COMMIT_ID, toCommitId);
             try (DiffFormatter diffFormatter = new DiffFormatter(null)) {
                 diffFormatter.setRepository(repository);
@@ -254,7 +288,7 @@ public class GitDataStore extends AbstractDataStore {
                 });
             }
             if (dataConfig != null) {
-                updateDataConfig(dataConfig, toCommitId);
+                updateDataConfig(dataConfig, currentSourceRef, toCommitId);
             }
         } catch (final Exception e) {
             throw new DataStoreException(e);
@@ -262,12 +296,16 @@ public class GitDataStore extends AbstractDataStore {
             try {
                 repository.close();
             } finally {
-                final File gitRepoPath = (File) configMap.get(TEMP_REPOSITORY_PATH);
-                if (gitRepoPath != null) {
-                    try (Stream<Path> walk = Files.walk(gitRepoPath.toPath())) {
-                        walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-                    } catch (final IOException e) {
-                        logger.warn("Failed to delete {}.", gitRepoPath.getAbsolutePath(), e);
+                try {
+                    releaseRepositoryLock(configMap);
+                } finally {
+                    final File gitRepoPath = (File) configMap.get(TEMP_REPOSITORY_PATH);
+                    if (gitRepoPath != null) {
+                        try (Stream<Path> walk = Files.walk(gitRepoPath.toPath())) {
+                            walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+                        } catch (final IOException e) {
+                            logger.warn("Failed to delete {}.", gitRepoPath.getAbsolutePath(), e);
+                        }
                     }
                 }
             }
@@ -291,33 +329,248 @@ public class GitDataStore extends AbstractDataStore {
     }
 
     /**
-     * Updates the data configuration with the new commit ID.
+     * Updates the data configuration with the new commit ID and source ref.
+     * <p>
+     * Both {@link #PREV_COMMIT_ID} and {@link #PREV_SOURCE_REF} are written back using the same
+     * "update in place if the key already exists, otherwise append" strategy so that a repeat run
+     * can detect when the {@code uri}/branch has changed and fall back to a full reindex.
+     * </p>
      *
      * @param dataConfig The data configuration.
+     * @param sourceRef The current source ref ({@code uri + "#" + resolved commit ref}).
      * @param toCommitId The new commit ID.
      */
-    protected void updateDataConfig(final DataConfig dataConfig, final ObjectId toCommitId) {
-        final Map<String, String> handlerParameterMap = dataConfig.getHandlerParameterMap();
-        final boolean hasPrevCommitId = handlerParameterMap.containsKey(PREV_COMMIT_ID);
-        final String paramStr;
-        if (hasPrevCommitId) {
-            paramStr = handlerParameterMap.entrySet().stream().map(e -> {
-                if (PREV_COMMIT_ID.equals(e.getKey())) {
-                    return e.getKey() + "=" + toCommitId.name();
-                }
-                return e.getKey() + "=" + e.getValue();
-            }).collect(Collectors.joining("\n"));
-        } else {
-            final String existing =
-                    handlerParameterMap.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining("\n"));
-            paramStr = existing + "\n" + PREV_COMMIT_ID + "=" + toCommitId.name();
-        }
+    protected void updateDataConfig(final DataConfig dataConfig, final String sourceRef, final ObjectId toCommitId) {
+        final String paramStr = buildHandlerParameter(dataConfig.getHandlerParameterMap(), toCommitId.name(), sourceRef);
         dataConfig.setHandlerParameter(paramStr);
         if (logger.isDebugEnabled()) {
             logger.debug("Updating data config by {}.", paramStr);
         }
         ComponentUtil.getComponent(DataConfigBhv.class).update(dataConfig);
         logger.info("Updated DataConfig: {}", dataConfig.getId());
+    }
+
+    /**
+     * Builds the {@code handlerParameter} string with {@link #PREV_COMMIT_ID} and {@link #PREV_SOURCE_REF}
+     * applied using an "update in place if the key already exists, otherwise append" strategy so that
+     * existing keys keep their position and are never duplicated.
+     *
+     * @param handlerParameterMap The current handler parameter map.
+     * @param prevCommitId The commit ID to persist as {@link #PREV_COMMIT_ID}.
+     * @param prevSourceRef The source ref to persist as {@link #PREV_SOURCE_REF}.
+     * @return The rebuilt {@code handlerParameter} string.
+     */
+    protected String buildHandlerParameter(final Map<String, String> handlerParameterMap, final String prevCommitId,
+            final String prevSourceRef) {
+        final Map<String, String> newValues = new LinkedHashMap<>();
+        newValues.put(PREV_COMMIT_ID, prevCommitId);
+        newValues.put(PREV_SOURCE_REF, prevSourceRef);
+
+        final StringBuilder buf = new StringBuilder();
+        handlerParameterMap.forEach((key, value) -> {
+            if (buf.length() > 0) {
+                buf.append('\n');
+            }
+            buf.append(key).append('=').append(newValues.getOrDefault(key, value));
+        });
+        newValues.forEach((key, value) -> {
+            if (!handlerParameterMap.containsKey(key)) {
+                if (buf.length() > 0) {
+                    buf.append('\n');
+                }
+                buf.append(key).append('=').append(value);
+            }
+        });
+        return buf.toString();
+    }
+
+    /**
+     * Resolves the commit reference to use for checkout and diffing.
+     * <p>
+     * When {@code commitId} defaults to {@link org.eclipse.jgit.lib.Constants#HEAD} (or is blank), the
+     * remote's advertised {@code HEAD} is inspected to determine the actual default branch (e.g.
+     * {@code refs/heads/main}). {@code FetchCommand} does not update the local {@code HEAD}, so if the
+     * advertised {@code HEAD} is symbolic the local {@code HEAD} is linked to that branch (mirroring
+     * {@code CloneCommand}); this lets {@link #hasCommitLogs(Map)} resolve correctly on subsequent runs
+     * against a persistent {@code repository_path}.
+     * </p>
+     *
+     * @param repository The Git repository.
+     * @param fetchResult The result of the fetch operation.
+     * @param commitId The configured commit ID.
+     * @return The resolved commit reference to use for checkout and resolution.
+     * @throws IOException If updating the local {@code HEAD} fails.
+     */
+    protected String resolveDefaultBranch(final Repository repository, final FetchResult fetchResult, final String commitId)
+            throws IOException {
+        if (StringUtil.isNotBlank(commitId) && !org.eclipse.jgit.lib.Constants.HEAD.equals(commitId)) {
+            return commitId;
+        }
+        final Ref headRef = fetchResult.getAdvertisedRef(org.eclipse.jgit.lib.Constants.HEAD);
+        if (headRef == null) {
+            return commitId;
+        }
+        if (headRef.isSymbolic()) {
+            final String targetName = headRef.getTarget().getName();
+            final RefUpdate newHead = repository.updateRef(org.eclipse.jgit.lib.Constants.HEAD);
+            newHead.disableRefLog();
+            newHead.link(targetName);
+            return targetName;
+        }
+        return headRef.getObjectId().name();
+    }
+
+    /**
+     * Resolves the target commit and fails fast if it cannot be resolved.
+     * <p>
+     * Resolving must happen before any diff/delete work: a {@code null} target would otherwise be treated
+     * by JGit's diff as an empty tree, marking every previously-tracked file as a deletion.
+     * </p>
+     *
+     * @param repository The Git repository.
+     * @param commitId The configured commit ID (used only for the error message).
+     * @param resolvedCommitId The resolved commit reference to look up.
+     * @return The resolved target commit ID (never {@code null}).
+     * @throws IOException If resolution fails at the I/O level.
+     */
+    protected ObjectId resolveToCommitId(final Repository repository, final String commitId, final String resolvedCommitId)
+            throws IOException {
+        final ObjectId toCommitId = repository.resolve(resolvedCommitId);
+        if (toCommitId == null) {
+            throw new DataStoreException("Could not resolve commit_id '" + commitId
+                    + "'. The branch/tag may not exist, or may have been renamed/deleted upstream.");
+        }
+        return toCommitId;
+    }
+
+    /**
+     * Determines whether the recorded source ref matches the current run's source ref.
+     * <p>
+     * A blank {@code prevSourceRef} (e.g. a config that predates this tracking param, or a manually-set
+     * {@code prev_commit_id}) is treated as a match so that existing incremental behavior is preserved.
+     * </p>
+     *
+     * @param prevSourceRef The source ref recorded on the previous run.
+     * @param currentSourceRef The source ref of the current run.
+     * @return {@code true} if the previous {@code prev_commit_id} can be trusted for an incremental diff.
+     */
+    protected boolean isSameSource(final String prevSourceRef, final String currentSourceRef) {
+        if (StringUtil.isBlank(prevSourceRef)) {
+            return true;
+        }
+        return prevSourceRef.equals(currentSourceRef);
+    }
+
+    /**
+     * Acquires an OS-level advisory lock on a persistent {@code repository_path} and removes any stale
+     * JGit lock files.
+     * <p>
+     * The marker file sits next to {@code .git} so it is never touched by the stale-lock scan. Because the
+     * OS releases the {@link FileLock} automatically when the holding process dies (including via SIGKILL),
+     * a run killed a moment ago will not block the next run, whereas a genuinely concurrent live run will.
+     * Once the lock is held we are the sole owner of the directory, so any {@code *.lock} file under
+     * {@code .git} is guaranteed stale and is deleted.
+     * </p>
+     *
+     * @param repositoryPath The persistent repository directory.
+     * @param configMap The configuration map; the lock and channel are stored here for later release.
+     */
+    protected void lockRepositoryPath(final File repositoryPath, final Map<String, Object> configMap) {
+        final File markerFile = new File(repositoryPath, LOCK_FILE_NAME);
+        FileChannel channel = null;
+        FileLock lock = null;
+        try {
+            channel = FileChannel.open(markerFile.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            lock = channel.tryLock();
+        } catch (final OverlappingFileLockException e) {
+            // tryLock() throws instead of returning null when this JVM already holds an overlapping lock.
+            lock = null;
+        } catch (final IOException e) {
+            closeChannelQuietly(channel);
+            throw new DataStoreException("Failed to acquire a lock on repository_path " + repositoryPath.getAbsolutePath(), e);
+        }
+        if (lock == null) {
+            closeChannelQuietly(channel);
+            throw new DataStoreException("Another crawl appears to be using repository_path '" + repositoryPath.getAbsolutePath()
+                    + "'. If no crawl is actually running, a stale lock file may need manual cleanup: " + markerFile.getAbsolutePath());
+        }
+        configMap.put(REPOSITORY_LOCK_CHANNEL, channel);
+        configMap.put(REPOSITORY_LOCK, lock);
+        deleteStaleLockFiles(new File(repositoryPath, ".git"));
+    }
+
+    /**
+     * Deletes stale JGit {@code *.lock} files under the given {@code .git} directory. Must only be called
+     * while holding the {@link #lockRepositoryPath} advisory lock, which guarantees the files are stale.
+     *
+     * @param gitDir The {@code .git} directory to scan.
+     */
+    protected void deleteStaleLockFiles(final File gitDir) {
+        if (gitDir == null || !gitDir.isDirectory()) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(gitDir.toPath())) {
+            walk.filter(Files::isRegularFile).filter(p -> p.getFileName().toString().endsWith(".lock")).forEach(p -> {
+                final File lockFile = p.toFile();
+                logger.warn("Removing stale Git lock file (likely left by a previously interrupted crawl): {}", lockFile.getAbsolutePath());
+                if (!lockFile.delete()) {
+                    logger.warn("Failed to delete stale Git lock file: {}", lockFile.getAbsolutePath());
+                }
+            });
+        } catch (final IOException e) {
+            logger.warn("Failed to scan for stale Git lock files under {}.", gitDir.getAbsolutePath(), e);
+        }
+    }
+
+    /**
+     * Releases the repository lock and closes its channel, if present. Best-effort: the OS releases the
+     * lock anyway if the process is killed.
+     *
+     * @param configMap The configuration map holding the lock and channel.
+     */
+    protected void releaseRepositoryLock(final Map<String, Object> configMap) {
+        final FileLock lock = (FileLock) configMap.get(REPOSITORY_LOCK);
+        if (lock != null) {
+            try {
+                lock.release();
+            } catch (final IOException e) {
+                logger.debug("Failed to release the repository lock.", e);
+            }
+        }
+        closeChannelQuietly((FileChannel) configMap.get(REPOSITORY_LOCK_CHANNEL));
+    }
+
+    private void closeChannelQuietly(final FileChannel channel) {
+        if (channel != null) {
+            try {
+                channel.close();
+            } catch (final IOException e) {
+                logger.debug("Failed to close the repository lock channel.", e);
+            }
+        }
+    }
+
+    /**
+     * Redacts any user-info (e.g. {@code user:token@}) embedded in a Git URI so it is safe to log.
+     * Falls back to the original string if it cannot be parsed as a URI.
+     *
+     * @param url The Git URI.
+     * @return The URI with any user-info component removed.
+     */
+    protected String redactUrl(final String url) {
+        if (StringUtil.isBlank(url)) {
+            return url;
+        }
+        try {
+            final URI parsed = new URI(url);
+            if (parsed.getUserInfo() == null) {
+                return url;
+            }
+            return new URI(parsed.getScheme(), null, parsed.getHost(), parsed.getPort(), parsed.getPath(), parsed.getQuery(),
+                    parsed.getFragment()).toString();
+        } catch (final URISyntaxException e) {
+            return url;
+        }
     }
 
     /**
@@ -357,7 +610,7 @@ public class GitDataStore extends AbstractDataStore {
         final String uri = (String) configMap.get(URI);
         final DiffEntry diffEntry = (DiffEntry) configMap.get(DIFF_ENTRY);
         final String path = diffEntry.getNewPath();
-        final StatsKeyObject statsKey = new StatsKeyObject(uri);
+        final StatsKeyObject statsKey = new StatsKeyObject(redactUrl(uri));
         paramMap.put(Constants.CRAWLER_STATS_KEY, statsKey);
         try {
             crawlerStatsHelper.begin(statsKey);
@@ -367,6 +620,8 @@ public class GitDataStore extends AbstractDataStore {
             logger.info("Crawling Path: {}", path);
 
             final Map<String, Object> resultMap = new LinkedHashMap<>(paramMap.asMap());
+            resultMap.remove(USERNAME);
+            resultMap.remove(PASSWORD);
             final Repository repository = (Repository) configMap.get(REPOSITORY);
             final ObjectLoader objectLoader = repository.open(diffEntry.getNewId().toObjectId());
             final long size = objectLoader.getSize();
@@ -400,14 +655,14 @@ public class GitDataStore extends AbstractDataStore {
                         throw e;
                     }
                     if (logger.isDebugEnabled()) {
-                        logger.warn("Could not get a text from {}.", uri, e);
+                        logger.warn("Could not get a text from {}.", redactUrl(uri), e);
                     } else {
-                        logger.warn("Could not get a text from {}. {}", uri, e.getMessage());
+                        logger.warn("Could not get a text from {}. {}", redactUrl(uri), e.getMessage());
                     }
                 }
 
                 resultMap.put("url", getUrl(paramMap, path));
-                resultMap.put("uri", uri);
+                resultMap.put("uri", redactUrl(uri));
                 resultMap.put("path", path);
                 resultMap.put("name", name);
                 resultMap.put("crawlingConfig", dataConfig);
@@ -475,14 +730,14 @@ public class GitDataStore extends AbstractDataStore {
                     throw e;
                 }
             } else {
-                url = uri + ":" + path;
+                url = redactUrl(uri) + ":" + path;
             }
             final FailureUrlService failureUrlService = ComponentUtil.getComponent(FailureUrlService.class);
             failureUrlService.store(dataConfig, errorName, url, target);
             crawlerStatsHelper.record(statsKey, StatsAction.ACCESS_EXCEPTION);
         } catch (final Throwable t) {
             logger.warn("Crawling Access Exception at : {}", dataMap, t);
-            final String url = uri + ":" + path;
+            final String url = redactUrl(uri) + ":" + path;
             final FailureUrlService failureUrlService = ComponentUtil.getComponent(FailureUrlService.class);
             failureUrlService.store(dataConfig, t.getClass().getCanonicalName(), url, t);
 
@@ -527,11 +782,19 @@ public class GitDataStore extends AbstractDataStore {
     protected RevCommit getRevCommit(final Map<String, Object> configMap, final String path) throws GitAPIException, IOException {
         final Git git = (Git) configMap.get(GIT);
         final ObjectId currentCommitId = (ObjectId) configMap.get(CURRENT_COMMIT_ID);
-        final Iterator<RevCommit> revCommitIter = git.log().add(currentCommitId).addPath(path).setMaxCount(1).call().iterator();
-        if (!revCommitIter.hasNext()) {
-            throw new DataStoreException("Failed to parse git log for " + path);
+        final Iterable<RevCommit> revCommits = git.log().add(currentCommitId).addPath(path).setMaxCount(1).call();
+        // LogCommand.call() returns its own internal RevWalk (it ends with "return walk;") and never closes it,
+        // so the returned Iterable can be cast back to that RevWalk and closed to avoid leaking pack-file handles.
+        try (RevWalk revWalk = (RevWalk) revCommits) {
+            final Iterator<RevCommit> revCommitIter = revCommits.iterator();
+            if (!revCommitIter.hasNext()) {
+                throw new DataStoreException("Failed to parse git log for " + path);
+            }
+            final RevCommit revCommit = revCommitIter.next();
+            // Eagerly load the commit body so author/committer/timestamp remain readable after the walk is closed.
+            revWalk.parseBody(revCommit);
+            return revCommit;
         }
-        return revCommitIter.next();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
+import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -81,6 +82,7 @@ import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.FetchResult;
 import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
 /**
@@ -207,19 +209,44 @@ public class GitDataStore extends AbstractDataStore {
             logger.warn("base_url is blank: indexed document URLs will be empty and delete/rename tracking will be skipped.");
         }
 
-        final Map<String, Object> configMap = createConfigMap(paramMap);
-        configMap.put(URI, uri);
-
+        // getUrlFilter()/logger.info() only depend on paramMap/uri (not on configMap/the lock below), so they
+        // are deliberately resolved BEFORE the lock is acquired: getUrlFilter() can throw (e.g.
+        // ComponentNotFoundException, or CrawlerSystemException from UrlFilterImpl#init), and if that
+        // happened between lock acquisition and the try/finally that releases it, the lock would leak for the
+        // life of the JVM -- blocking every future crawl of this repository_path, i.e. exactly the
+        // repeated-crawl-failure class this PR exists to eliminate.
         final UrlFilter urlFilter = getUrlFilter(paramMap);
 
         logger.info("Git: {}", redactUrl(uri));
 
+        // The advisory lock must be acquired BEFORE createConfigMap() has a chance to initialize a brand-new
+        // repository_path (repository.create() writes HEAD/config/description/refs/objects non-atomically):
+        // otherwise the very first concurrent use of a not-yet-existing repository_path by two overlapping
+        // crawls would race unprotected. A lock-holder map is used (rather than configMap directly) because
+        // configMap does not exist until createConfigMap() returns; it is merged in below once available so
+        // the normal cleanup path (releaseRepositoryLock(configMap) in the finally block) still applies.
+        final Map<String, Object> lockHolder = new HashMap<>();
+        if (StringUtil.isNotBlank(repositoryPath)) {
+            final File repoDir = new File(repositoryPath);
+            // Idempotent and harmless even under a genuine race: unlike JGit's multi-file repository.create(),
+            // creating an empty directory concurrently has no corruption risk. It only exists to give the
+            // lock marker file (below) somewhere to live.
+            repoDir.mkdirs();
+            lockRepositoryPath(repoDir, lockHolder);
+        }
+        final Map<String, Object> configMap;
+        try {
+            configMap = createConfigMap(paramMap);
+        } catch (final Exception e) {
+            releaseRepositoryLock(lockHolder);
+            throw new DataStoreException("Failed to initialize Git repository " + redactUrl(uri), e);
+        }
+        configMap.putAll(lockHolder);
+        configMap.put(URI, uri);
+
         final Repository repository = (Repository) configMap.get(REPOSITORY);
         try (final Git git = new Git(repository)) {
             configMap.put(GIT, git);
-            if (StringUtil.isNotBlank(repositoryPath)) {
-                lockRepositoryPath(new File(repositoryPath), configMap);
-            }
             final FetchResult fetchResult = git.fetch()
                     .setForceUpdate(true)
                     .setRemote(uri)
@@ -291,7 +318,13 @@ public class GitDataStore extends AbstractDataStore {
                 updateDataConfig(dataConfig, currentSourceRef, toCommitId);
             }
         } catch (final Exception e) {
-            throw new DataStoreException(e);
+            // Give DataStoreException its own redacted top-level message rather than relying on the wrapped
+            // cause's message: JGit's TransportException (thrown by TransportHttp/TransportGitSsh on
+            // auth/network failures) embeds the target URI in its own getMessage() with only the password
+            // stripped (via URIish#setPass(null)) -- the username (e.g. a PAT-style credential used as
+            // username) is left in. The cause itself is still attached (and its message/stack trace may still
+            // contain the unredacted username if logged directly), so this only scrubs the primary message.
+            throw new DataStoreException("Failed to crawl Git repository " + redactUrl(uri), e);
         } finally {
             try {
                 repository.close();
@@ -394,6 +427,15 @@ public class GitDataStore extends AbstractDataStore {
      * {@code CloneCommand}); this lets {@link #hasCommitLogs(Map)} resolve correctly on subsequent runs
      * against a persistent {@code repository_path}.
      * </p>
+     * <p>
+     * Some transports/servers don't advertise the git symref capability for {@code HEAD}, in which case the
+     * advertised {@code HEAD} ref is not symbolic. Mirroring JGit's own
+     * {@code CloneCommand#findBranchToCheckout(FetchResult)}, {@code refs/heads/*} is scanned for a ref whose
+     * object id matches {@code HEAD}'s object id so a real branch name can still be identified by content; a
+     * bare commit SHA is used only if genuinely nothing matches (detached/anonymous history). A raw SHA here
+     * would otherwise make {@link #isSameSource(String, String)} flip-flop across runs with no actual
+     * branch/uri change, since the SHA moves as the branch advances.
+     * </p>
      *
      * @param repository The Git repository.
      * @param fetchResult The result of the fetch operation.
@@ -412,12 +454,51 @@ public class GitDataStore extends AbstractDataStore {
         }
         if (headRef.isSymbolic()) {
             final String targetName = headRef.getTarget().getName();
-            final RefUpdate newHead = repository.updateRef(org.eclipse.jgit.lib.Constants.HEAD);
-            newHead.disableRefLog();
-            newHead.link(targetName);
+            linkLocalHead(repository, targetName);
             return targetName;
         }
+        final String matchedBranch = findAdvertisedBranchByObjectId(fetchResult.getAdvertisedRefs(), headRef.getObjectId());
+        if (matchedBranch != null) {
+            linkLocalHead(repository, matchedBranch);
+            return matchedBranch;
+        }
         return headRef.getObjectId().name();
+    }
+
+    /**
+     * Links the local {@code HEAD} to the given target ref name, without writing a reflog entry.
+     *
+     * @param repository The Git repository.
+     * @param targetName The ref name to link {@code HEAD} to (e.g. {@code refs/heads/main}).
+     * @throws IOException If updating the local {@code HEAD} fails.
+     */
+    private void linkLocalHead(final Repository repository, final String targetName) throws IOException {
+        final RefUpdate newHead = repository.updateRef(org.eclipse.jgit.lib.Constants.HEAD);
+        newHead.disableRefLog();
+        newHead.link(targetName);
+    }
+
+    /**
+     * Scans the given advertised refs for one under {@code refs/heads/} whose object id matches {@code headId}.
+     * Used by {@link #resolveDefaultBranch(Repository, FetchResult, String)} to identify a branch name by
+     * content when the advertised {@code HEAD} is not symbolic, mirroring JGit's own
+     * {@code CloneCommand#findBranchToCheckout(FetchResult)}.
+     *
+     * @param advertisedRefs The refs advertised by the remote.
+     * @param headId The object id that the remote's {@code HEAD} points at, or {@code null}.
+     * @return The name of a matching {@code refs/heads/*} ref, or {@code null} if none matches.
+     */
+    protected String findAdvertisedBranchByObjectId(final Iterable<Ref> advertisedRefs, final ObjectId headId) {
+        if (headId == null) {
+            return null;
+        }
+        for (final Ref ref : advertisedRefs) {
+            final String name = ref.getName();
+            if (name != null && name.startsWith(org.eclipse.jgit.lib.Constants.R_HEADS) && headId.equals(ref.getObjectId())) {
+                return name;
+            }
+        }
+        return null;
     }
 
     /**
@@ -502,6 +583,16 @@ public class GitDataStore extends AbstractDataStore {
     /**
      * Deletes stale JGit {@code *.lock} files under the given {@code .git} directory. Must only be called
      * while holding the {@link #lockRepositoryPath} advisory lock, which guarantees the files are stale.
+     * <p>
+     * This scan is best-effort and must never propagate a failure: it runs immediately after the advisory
+     * lock has already been acquired and stored by the caller, with no surrounding try/catch, so an
+     * uncaught exception here would skip the caller's cleanup and leak that lock for the life of the JVM.
+     * Individual file {@code delete()} failures are already just logged; both {@link IOException} (thrown by
+     * {@link Files#walk(Path, java.nio.file.FileVisitOption...)} itself) and {@link UncheckedIOException}
+     * (which {@code Files.walk()}'s returned {@link Stream} can throw mid-traversal, e.g. on a
+     * permission-denied or concurrently-deleted subdirectory) are therefore caught and logged rather than
+     * allowed to escape.
+     * </p>
      *
      * @param gitDir The {@code .git} directory to scan.
      */
@@ -519,6 +610,11 @@ public class GitDataStore extends AbstractDataStore {
             });
         } catch (final IOException e) {
             logger.warn("Failed to scan for stale Git lock files under {}.", gitDir.getAbsolutePath(), e);
+        } catch (final UncheckedIOException e) {
+            // Thrown by the Stream during traversal (not by Files.walk() itself), so it is not an IOException
+            // and would otherwise bypass the catch above. Log the wrapped cause, same as the IOException case.
+            logger.warn("Failed to scan for stale Git lock files under {}.", gitDir.getAbsolutePath(),
+                    e.getCause() != null ? e.getCause() : e);
         }
     }
 
@@ -550,27 +646,94 @@ public class GitDataStore extends AbstractDataStore {
         }
     }
 
+    /** Matches a scheme + {@code "://"} prefix (e.g. {@code https://}); used by {@link #maskConservatively(String)}
+     *  to separate the scheme from the remainder of an otherwise-unparseable URL. */
+    private static final Pattern SCHEME_PREFIX_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9+.-]*://");
+
     /**
-     * Redacts any user-info (e.g. {@code user:token@}) embedded in a Git URI so it is safe to log.
-     * Falls back to the original string if it cannot be parsed as a URI.
+     * Redacts any user-info (e.g. {@code user:token@}) embedded in a Git URI so it is safe to log, persist in
+     * {@link #PREV_SOURCE_REF}, and index (see {@code resultMap.put("uri", ...)} in {@link #processFile}).
+     * <p>
+     * This method is fail-CLOSED: on any parse ambiguity it masks conservatively rather than ever returning
+     * credential-bearing input unchanged. {@link java.net.URI} is deliberately NOT used here: it is a strict
+     * RFC-3986 parser that throws {@link URISyntaxException} on scp-style Git remotes ({@code user@host:path})
+     * and on unescaped reserved characters (e.g. {@code @}, {@code /}) that commonly appear in real Git
+     * tokens/passwords -- and a naive implementation would return the raw, unredacted url on any such parse
+     * failure. {@link URIish} is used instead: it is already a project dependency (used elsewhere in this file
+     * for the actual git operations) and is far more lenient with Git's real-world remote URL syntax.
+     * </p>
+     * <p>
+     * Known residual limitation: {@link URIish} itself can misparse an authority containing an unescaped
+     * {@code /} inside the password by folding the whole authority into the path instead of throwing; this is
+     * detected here (a scheme was recognized but no host was) and handled by {@link #maskConservatively(String)}.
+     * The equivalent failure for a schemeless scp-style URL (e.g. {@code user:pa/ss@host:path}) is not
+     * specifically detected, since real scp-style Git remotes authenticate via SSH keys rather than
+     * URL-embedded passwords, making that combination exotic in practice.
+     * </p>
      *
      * @param url The Git URI.
-     * @return The URI with any user-info component removed.
+     * @return The URI with any user-info component removed, or a conservatively-masked string if the input
+     *         could not be confidently parsed.
      */
     protected String redactUrl(final String url) {
         if (StringUtil.isBlank(url)) {
             return url;
         }
         try {
-            final URI parsed = new URI(url);
-            if (parsed.getUserInfo() == null) {
-                return url;
+            final URIish parsed = new URIish(url);
+            if (parsed.getUser() != null || parsed.getPass() != null) {
+                return parsed.setUser(null).setPass(null).toString();
             }
-            return new URI(parsed.getScheme(), null, parsed.getHost(), parsed.getPort(), parsed.getPath(), parsed.getQuery(),
-                    parsed.getFragment()).toString();
-        } catch (final URISyntaxException e) {
+            if ((parsed.getScheme() != null || SCHEME_PREFIX_PATTERN.matcher(url).find()) && parsed.getHost() == null) {
+                // A scheme was recognized but no host was -- typically because an unescaped '/' inside a
+                // password broke authority parsing and the whole authority (including any credentials) was
+                // folded into the path instead of being reported as user/pass. Treat this as unparseable.
+                //
+                // The SCHEME_PREFIX_PATTERN check additionally covers an uppercase/mixed-case scheme (e.g.
+                // "HTTPS://"): URIish's internal SCHEME_P regex is lowercase-only, so it fails to match the
+                // normal FULL_URI pattern for such input and silently falls through to the lenient
+                // LOCAL_FILE catch-all, which treats the whole string as an opaque local path -- scheme,
+                // host, user and pass all come back null. Matching the original input against
+                // SCHEME_PREFIX_PATTERN (case-insensitive by construction) detects that case too, without
+                // misrouting a genuine schemeless local path (which never matches the pattern).
+                return maskConservatively(url);
+            }
             return url;
+        } catch (final URISyntaxException | RuntimeException e) {
+            // RuntimeException covers cases like NumberFormatException on an out-of-range port, which
+            // URIish's constructor can throw without wrapping it as a URISyntaxException. Never fall through
+            // to returning the raw url.
+            return maskConservatively(url);
         }
+    }
+
+    /**
+     * Conservatively masks anything that looks like embedded user-info in a URL that {@link URIish} could not
+     * confidently parse. Strips everything between an optional {@code scheme://} prefix and the last {@code @}
+     * found afterward (or, for scp-style/schemeless input, the last {@code @} anywhere in the string), on the
+     * assumption that a Git remote URL never legitimately needs a bare {@code @} in that position other than as
+     * a user-info separator. If no {@code @} is found there, there is nothing recognizable to strip and the
+     * input is returned unchanged.
+     *
+     * @param url The url to mask.
+     * @return The masked url.
+     */
+    protected String maskConservatively(final String url) {
+        final Matcher schemeMatcher = SCHEME_PREFIX_PATTERN.matcher(url);
+        final String prefix;
+        final String rest;
+        if (schemeMatcher.find()) {
+            prefix = schemeMatcher.group();
+            rest = url.substring(prefix.length());
+        } else {
+            prefix = StringUtil.EMPTY;
+            rest = url;
+        }
+        final int lastAt = rest.lastIndexOf('@');
+        if (lastAt < 0) {
+            return prefix + rest;
+        }
+        return prefix + rest.substring(lastAt + 1);
     }
 
     /**
@@ -759,8 +922,9 @@ public class GitDataStore extends AbstractDataStore {
      */
     protected boolean hasCommitLogs(final Map<String, Object> configMap) {
         final Git git = (Git) configMap.get(GIT);
-        try {
-            git.log().call();
+        // LogCommand.call() returns its own internal RevWalk (it ends with "return walk;") and never closes it,
+        // so the returned Iterable can be cast back to that RevWalk and closed to avoid leaking pack-file handles.
+        try (RevWalk revWalk = (RevWalk) git.log().call()) {
             return true;
         } catch (final Exception e) {
             if (logger.isDebugEnabled()) {
@@ -850,12 +1014,17 @@ public class GitDataStore extends AbstractDataStore {
         } else {
             try {
                 final File repoFile = new File(repositoryPath);
-                final boolean exists = repoFile.exists();
-                if (!exists) {
+                if (!repoFile.exists()) {
                     repoFile.mkdirs();
                 }
-                final Repository repository = FileRepositoryBuilder.create(new File(repositoryPath, ".git"));
-                if (!exists) {
+                // Checked on the .git directory itself, not the parent repoFile: storeData() may already have
+                // created the parent directory (to have somewhere to put the advisory lock marker file) before
+                // this method runs, so repoFile.exists() alone would no longer reliably indicate whether this
+                // is a brand-new repository that still needs repository.create().
+                final File gitDir = new File(repositoryPath, ".git");
+                final boolean gitDirExists = gitDir.exists();
+                final Repository repository = FileRepositoryBuilder.create(gitDir);
+                if (!gitDirExists) {
                     repository.create();
                 }
                 configMap.put(REPOSITORY, repository);

--- a/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
@@ -318,13 +318,13 @@ public class GitDataStore extends AbstractDataStore {
                 updateDataConfig(dataConfig, currentSourceRef, toCommitId);
             }
         } catch (final Exception e) {
-            // Give DataStoreException its own redacted top-level message rather than relying on the wrapped
-            // cause's message: JGit's TransportException (thrown by TransportHttp/TransportGitSsh on
-            // auth/network failures) embeds the target URI in its own getMessage() with only the password
-            // stripped (via URIish#setPass(null)) -- the username (e.g. a PAT-style credential used as
-            // username) is left in. The cause itself is still attached (and its message/stack trace may still
-            // contain the unredacted username if logged directly), so this only scrubs the primary message.
-            throw new DataStoreException("Failed to crawl Git repository " + redactUrl(uri), e);
+            // Redact both the DataStoreException's own top-level message AND the wrapped cause chain: JGit's
+            // TransportException (thrown by TransportHttp/TransportGitSsh on auth/network failures) embeds the
+            // target URI in its own getMessage() with only the password stripped (via URIish#setPass(null)) --
+            // the username (e.g. a PAT-style credential used as username) is left in. That cause message is what
+            // log4j2 prints as "Caused by:" and what failure-url reporting persists, so redactCredentialsInChain
+            // scrubs every level of the chain before it is attached.
+            throw new DataStoreException("Failed to crawl Git repository " + redactUrl(uri), redactCredentialsInChain(e));
         } finally {
             try {
                 repository.close();
@@ -481,8 +481,12 @@ public class GitDataStore extends AbstractDataStore {
     /**
      * Scans the given advertised refs for one under {@code refs/heads/} whose object id matches {@code headId}.
      * Used by {@link #resolveDefaultBranch(Repository, FetchResult, String)} to identify a branch name by
-     * content when the advertised {@code HEAD} is not symbolic, mirroring JGit's own
-     * {@code CloneCommand#findBranchToCheckout(FetchResult)}.
+     * content when the advertised {@code HEAD} is not symbolic. This is similar in intent to JGit's own
+     * {@code CloneCommand#findBranchToCheckout(FetchResult)}, but does NOT replicate its tiebreak: when several
+     * advertised branches share {@code HEAD}'s object id, JGit specially prefers {@code refs/heads/master},
+     * whereas this returns the first match in advertised-ref order. That is fine here because advertised-ref
+     * order is deterministic (server-advertised), not a source of run-to-run flapping; it only changes which
+     * branch name is picked on a genuine tie.
      *
      * @param advertisedRefs The refs advertised by the remote.
      * @param headId The object id that the remote's {@code HEAD} points at, or {@code null}.
@@ -518,8 +522,11 @@ public class GitDataStore extends AbstractDataStore {
             throws IOException {
         final ObjectId toCommitId = repository.resolve(resolvedCommitId);
         if (toCommitId == null) {
-            throw new DataStoreException("Could not resolve commit_id '" + commitId
-                    + "'. The branch/tag may not exist, or may have been renamed/deleted upstream.");
+            // Report the ref that actually failed to resolve (resolvedCommitId), not the configured commit_id:
+            // e.g. a configured "HEAD" resolves to "refs/heads/main", and it is that resolved ref which was
+            // unresolvable. The original configured value is still included for context.
+            throw new DataStoreException("Could not resolve commit_id '" + resolvedCommitId + "' (configured commit_id was '" + commitId
+                    + "'). The branch/tag may not exist, or may have been renamed/deleted upstream.");
         }
         return toCommitId;
     }
@@ -736,6 +743,70 @@ public class GitDataStore extends AbstractDataStore {
         return prefix + rest.substring(lastAt + 1);
     }
 
+    /** Matches a scheme + {@code "://"} + userinfo + {@code "@"} occurring anywhere in free text (e.g. inside a
+     *  JGit exception message), so the userinfo can be stripped without disturbing the rest of the message.
+     *  Used by {@link #redactCredentials(String)}. */
+    private static final Pattern EMBEDDED_CREDENTIAL_PATTERN = Pattern.compile("([A-Za-z][A-Za-z0-9+.-]*://)[^\\s/@]+@");
+
+    /** Safety bound on the cause-chain recursion in {@link #redactCredentialsInChain(Throwable)}: real JGit
+     *  chains are only a handful deep, but a cyclic chain (constructible via {@link Throwable#initCause(Throwable)},
+     *  e.g. {@code a -> b -> a}, which rejects only direct self-reference) would otherwise recurse forever. At
+     *  this depth the remaining cause is dropped rather than attached raw, so the result stays safe to
+     *  log/persist even in that never-seen-in-practice case. */
+    private static final int MAX_CAUSE_CHAIN_DEPTH = 20;
+
+    /**
+     * Strips any {@code scheme://userinfo@} occurring anywhere within free-form text (e.g. an exception
+     * message), leaving the scheme and the rest of the text untouched. Unlike {@link #redactUrl(String)}, this
+     * does not require the whole input to be a single URL: JGit exception messages typically embed the target
+     * URI (with the password already stripped but the username left in) inside a larger sentence such as
+     * {@code "https://user@host/repo.git: Connection refused"}.
+     *
+     * @param message The text to scrub.
+     * @return The text with any embedded {@code scheme://userinfo@} stripped, or the input unchanged if it
+     *         contained none (or was blank/{@code null}).
+     */
+    protected String redactCredentials(final String message) {
+        if (StringUtil.isBlank(message)) {
+            return message;
+        }
+        return EMBEDDED_CREDENTIAL_PATTERN.matcher(message).replaceAll("$1");
+    }
+
+    /**
+     * Returns a copy of the given throwable's cause chain with any embedded Git-URL user-info (see
+     * {@link #redactCredentials(String)}) stripped from every message in the chain, so it is safe to log or
+     * persist to a failure-url record. Preserves each level's original stack trace and embeds the original
+     * class name in the replacement message (so logs still show what type of error it was). A chain that needed
+     * no redaction anywhere is returned as the same instance (no pointless wrapping).
+     *
+     * @param throwable The throwable (possibly with a cause chain) to sanitize.
+     * @return A sanitized copy, or the original instance if nothing needed redaction, or {@code null} if the
+     *         input was {@code null}.
+     */
+    protected Throwable redactCredentialsInChain(final Throwable throwable) {
+        return redactCredentialsInChain(throwable, 0);
+    }
+
+    private Throwable redactCredentialsInChain(final Throwable throwable, final int depth) {
+        if (throwable == null) {
+            return null;
+        }
+        final String message = throwable.getMessage();
+        final String redactedMessage = redactCredentials(message);
+        final Throwable originalCause = throwable.getCause();
+        // Stop recursing at MAX_CAUSE_CHAIN_DEPTH and drop the remaining cause: a cyclic chain would otherwise
+        // recurse forever, and dropping the deeper cause keeps the result safe to log/persist even then.
+        final Throwable redactedCause = depth >= MAX_CAUSE_CHAIN_DEPTH ? null : redactCredentialsInChain(originalCause, depth + 1);
+        if (Objects.equals(message, redactedMessage) && redactedCause == originalCause) {
+            return throwable;
+        }
+        final RuntimeException sanitized = new RuntimeException(
+                throwable.getClass().getName() + (redactedMessage != null ? ": " + redactedMessage : StringUtil.EMPTY), redactedCause);
+        sanitized.setStackTrace(throwable.getStackTrace());
+        return sanitized;
+    }
+
     /**
      * Returns the file name from the given path.
      *
@@ -868,7 +939,11 @@ public class GitDataStore extends AbstractDataStore {
                 }
             }
         } catch (final CrawlingAccessException e) {
-            logger.warn("Crawling Access Exception at : {}", dataMap, e);
+            // The exception message may embed a Git URL with credentials (see redactCredentials); scrub the
+            // chain before it is logged or persisted. The original objects are still used below for the
+            // instanceof/errorName checks, which only read class names (never sensitive).
+            final Throwable redactedException = redactCredentialsInChain(e);
+            logger.warn("Crawling Access Exception at : {}", dataMap, redactedException);
 
             Throwable target = e;
             if (target instanceof MultipleCrawlingAccessException) {
@@ -896,13 +971,15 @@ public class GitDataStore extends AbstractDataStore {
                 url = redactUrl(uri) + ":" + path;
             }
             final FailureUrlService failureUrlService = ComponentUtil.getComponent(FailureUrlService.class);
-            failureUrlService.store(dataConfig, errorName, url, target);
+            failureUrlService.store(dataConfig, errorName, url, redactCredentialsInChain(target));
             crawlerStatsHelper.record(statsKey, StatsAction.ACCESS_EXCEPTION);
         } catch (final Throwable t) {
-            logger.warn("Crawling Access Exception at : {}", dataMap, t);
+            // Scrub any credential-bearing Git URL out of the message chain before logging/persisting it.
+            final Throwable redactedThrowable = redactCredentialsInChain(t);
+            logger.warn("Crawling Access Exception at : {}", dataMap, redactedThrowable);
             final String url = redactUrl(uri) + ":" + path;
             final FailureUrlService failureUrlService = ComponentUtil.getComponent(FailureUrlService.class);
-            failureUrlService.store(dataConfig, t.getClass().getCanonicalName(), url, t);
+            failureUrlService.store(dataConfig, t.getClass().getCanonicalName(), url, redactedThrowable);
 
             final long readInterval = (Long) configMap.get(READ_INTERVAL);
             if (readInterval > 0) {
@@ -1022,6 +1099,20 @@ public class GitDataStore extends AbstractDataStore {
                 // this method runs, so repoFile.exists() alone would no longer reliably indicate whether this
                 // is a brand-new repository that still needs repository.create().
                 final File gitDir = new File(repositoryPath, ".git");
+                // A run killed mid-initialization can leave .git as a partial skeleton. JGit's
+                // repository.create() writes .git/config LAST (its final cfg.save()) and refuses to re-run
+                // once config exists, so config's presence reliably marks a completed initialization and its
+                // absence marks an interrupted one. Because create() also runs BEFORE any fetch, a .git without
+                // config can never contain fetched data, so discarding it loses nothing. Delete the partial
+                // directory (only .git, never repositoryPath, whose advisory lock marker must survive) so the
+                // repository is re-created below -- a plain re-create() alone cannot repair it, as refs.create()
+                // throws on the already-existing refs/. A completed repo keeps its config and is left untouched.
+                if (gitDir.exists() && !new File(gitDir, org.eclipse.jgit.lib.Constants.CONFIG).exists()) {
+                    logger.warn("Removing an incomplete Git repository left by a previously interrupted crawl: {}",
+                            gitDir.getAbsolutePath());
+                    org.eclipse.jgit.util.FileUtils.delete(gitDir,
+                            org.eclipse.jgit.util.FileUtils.RECURSIVE | org.eclipse.jgit.util.FileUtils.SKIP_MISSING);
+                }
                 final boolean gitDirExists = gitDir.exists();
                 final Repository repository = FileRepositoryBuilder.create(gitDir);
                 if (!gitDirExists) {

--- a/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
@@ -58,6 +58,7 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
@@ -123,28 +124,24 @@ public class GitDataStoreTest extends UnitDsTestCase {
                 .call();
     }
 
+    // Hermetic fixture (no network/GitHub dependency): a local scratch repository standing in for the
+    // previous live "https://github.com/codelibs/fess-ds-git.git" clone. Since @Test annotations are fixed
+    // (they now actually run in CI), this test must not depend on network/GitHub availability.
     @Test
-    public void test_storeData() {
+    public void test_storeData() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("pom.xml", "<project/>");
+        files.put("README.md", "hello world");
+        files.put("src/main/java/App.java", "public class App {}");
+        final File remote = createLocalRepo("main", files);
+
         DataStoreParams params = new DataStoreParams();
-        params.put("uri", "https://github.com/codelibs/fess-ds-git.git");
+        params.put("uri", remote.getAbsolutePath());
         params.put("base_url", "https://github.com/codelibs/fess-ds-git/blob/master/");
         params.put("extractors",
                 "text/.*:textExtractor,application/xml:textExtractor,application/javascript:textExtractor,application/json:textExtractor,application/x-sh:textExtractor,application/x-bat:textExtractor,audio/.*:filenameExtractor,chemical/.*:filenameExtractor,image/.*:filenameExtractor,model/.*:filenameExtractor,video/.*:filenameExtractor,");
         final List<String> urlList = new ArrayList<>();
-        GitDataStore dataStore = new GitDataStore() {
-            @Override
-            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
-                return new MockUrlFilter();
-            }
-
-            @Override
-            protected void processFile(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
-                    final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final Map<String, Object> configMap) {
-                final DiffEntry diffEntry = (DiffEntry) configMap.get(DIFF_ENTRY);
-                final String path = diffEntry.getNewPath();
-                urlList.add(path);
-            }
-        };
+        GitDataStore dataStore = newCollectingDataStore(urlList);
         dataStore.storeData(null, null, params, null, null);
 
         assertTrue(urlList.stream().anyMatch(s -> s.endsWith("pom.xml")));
@@ -296,6 +293,62 @@ public class GitDataStoreTest extends UnitDsTestCase {
                 final String msg = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
                 assertTrue(msg != null && msg.contains("Another crawl appears to be using repository_path"));
             }
+        }
+    }
+
+    // Bug fix (post-review): deleteStaleLockFiles()'s Files.walk() can throw an UNCHECKED
+    // java.io.UncheckedIOException mid-traversal (e.g. AccessDeniedException on a subdirectory another tool
+    // is concurrently touching -- exactly the scenario this PR's own README caveat warns about), which is NOT
+    // caught by the existing `catch (final IOException e)` clause. Since lockRepositoryPath() ->
+    // deleteStaleLockFiles() is called from storeData() with no surrounding try/catch, an uncaught
+    // UncheckedIOException here would propagate straight out of storeData(), skipping the try/finally that
+    // calls releaseRepositoryLock() -- leaking the just-acquired advisory FileLock for the life of the JVM
+    // and blocking every future crawl of this repository_path.
+    @Test
+    public void test_storeData_staleLockScanIOErrorDoesNotLeakLock() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createLocalRepo("main", files);
+
+        final File persistent = Files.createTempDirectory("fess-ds-git-persist-").toFile();
+        tempDirs.add(persistent);
+        try (Repository repo = FileRepositoryBuilder.create(new File(persistent, ".git"))) {
+            repo.create();
+        }
+        // An unreadable/unsearchable subdirectory under .git makes Files.walk() throw UncheckedIOException
+        // mid-traversal (AccessDeniedException while trying to list it), rather than at the initial walk()
+        // call -- reproducing the real-world "another tool touching .git concurrently" failure mode.
+        final File unreadableDir = new File(persistent, ".git/unreadable-by-another-tool");
+        assertTrue(unreadableDir.mkdirs());
+        unreadableDir.setExecutable(false);
+        unreadableDir.setReadable(false);
+        // On a platform/user (e.g. root) where directory permission bits are not enforced, this
+        // reproduction cannot fire; skip rather than risk a flaky/misleading pass or failure.
+        org.junit.jupiter.api.Assumptions.assumeFalse(unreadableDir.canRead(),
+                "Directory read permission is not enforced for the current user; skipping.");
+
+        try {
+            final DataStoreParams params = new DataStoreParams();
+            params.put("uri", remote.getAbsolutePath());
+            params.put("repository_path", persistent.getAbsolutePath());
+            final List<String> urlList = new ArrayList<>();
+            newCollectingDataStore(urlList).storeData(null, null, params, null, null);
+
+            // The scan failure must be swallowed (logged) and the crawl must complete normally.
+            assertTrue(urlList.contains("a.txt"));
+
+            // The advisory lock must have been released -- a fresh, independent lock attempt on the same
+            // marker file (from this same JVM) must succeed. Pre-fix, the lock leaks and this would throw
+            // OverlappingFileLockException.
+            final File marker = new File(persistent, ".fess-ds-git.lock");
+            try (FileChannel channel = FileChannel.open(marker.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                    FileLock lock = channel.tryLock()) {
+                assertNotNull(lock);
+            }
+        } finally {
+            // Restore permissions so tearDown's deleteDirectory() can actually remove the temp tree.
+            unreadableDir.setReadable(true);
+            unreadableDir.setExecutable(true);
         }
     }
 
@@ -471,6 +524,206 @@ public class GitDataStoreTest extends UnitDsTestCase {
                 dataStore.resolveDefaultBranch(null, null, "0123456789abcdef0123456789abcdef01234567"));
     }
 
+    // Fix #11: for a brand-new (not-yet-existing) repository_path, the advisory lock must be acquired BEFORE
+    // any repository creation happens (repository.create() writes HEAD/config/description/refs/objects
+    // non-atomically). Before this fix, createConfigMap() (called before lockRepositoryPath()) would already
+    // have fully initialized the on-disk repo by the time the lock was even attempted -- meaning the very
+    // first concurrent use of a brand-new repository_path by two overlapping crawls was NOT protected by the
+    // lock at all. This is verified deterministically (no real thread race, which would be flaky) by
+    // instrumenting lockRepositoryPath() to record whether .git already exists at the moment it is called.
+    @Test
+    public void test_storeData_locksBeforeRepositoryCreate() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createLocalRepo("main", files);
+
+        final File persistentParent = Files.createTempDirectory("fess-ds-git-persist-").toFile();
+        tempDirs.add(persistentParent);
+        final File persistent = new File(persistentParent, "brand-new-repo"); // does not exist at all yet
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remote.getAbsolutePath());
+        params.put("repository_path", persistent.getAbsolutePath());
+
+        final List<String> urlList = new ArrayList<>();
+        final AtomicReference<Boolean> gitDirExistedAtLockTime = new AtomicReference<>();
+        final GitDataStore dataStore = new GitDataStore() {
+            @Override
+            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
+                return new MockUrlFilter();
+            }
+
+            @Override
+            protected void processFile(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
+                    final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final Map<String, Object> configMap) {
+                urlList.add(((DiffEntry) configMap.get(DIFF_ENTRY)).getNewPath());
+            }
+
+            @Override
+            protected void lockRepositoryPath(final File repositoryPath, final Map<String, Object> configMap) {
+                gitDirExistedAtLockTime.set(new File(repositoryPath, ".git").exists());
+                super.lockRepositoryPath(repositoryPath, configMap);
+            }
+        };
+        dataStore.storeData(null, null, params, null, null);
+
+        assertNotNull(gitDirExistedAtLockTime.get());
+        assertFalse(gitDirExistedAtLockTime.get());
+        assertTrue(urlList.contains("a.txt"));
+    }
+
+    // Fix #11 (regression guard): getUrlFilter() is resolved BEFORE the advisory lock is acquired specifically
+    // so that a getUrlFilter() failure (e.g. ComponentNotFoundException, or CrawlerSystemException from
+    // UrlFilterImpl#init) can never leave the lock held. A lock leaked here would never be released (nothing
+    // in storeData's try/finally runs, since the failure happens before either exists), blocking every future
+    // crawl of this repository_path until JVM restart -- exactly the repeated-crawl-failure class this PR
+    // exists to eliminate. Proven by making getUrlFilter() throw and then confirming the marker lock is still
+    // independently acquirable immediately afterward.
+    @Test
+    public void test_storeData_getUrlFilterFailureDoesNotLeakLock() throws Exception {
+        final File persistent = Files.createTempDirectory("fess-ds-git-persist-").toFile();
+        tempDirs.add(persistent);
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", "https://example.invalid/repo.git"); // never reached
+        params.put("repository_path", persistent.getAbsolutePath());
+
+        final GitDataStore dataStore = new GitDataStore() {
+            @Override
+            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
+                throw new RuntimeException("simulated getUrlFilter failure");
+            }
+        };
+
+        try {
+            dataStore.storeData(null, null, params, null, null);
+            fail("Expected RuntimeException");
+        } catch (final RuntimeException e) {
+            assertEquals("simulated getUrlFilter failure", e.getMessage());
+        }
+
+        final File marker = new File(persistent, ".fess-ds-git.lock");
+        try (FileChannel channel = FileChannel.open(marker.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                FileLock lock = channel.tryLock()) {
+            // Non-null proves the lock was never acquired (and thus never leaked) by the failed storeData call.
+            assertNotNull(lock);
+        }
+    }
+
+    // Fix #10: JGit's own TransportException embeds the target URI in its message with only the PASSWORD
+    // stripped (via URIish#setPass(null)) -- the USERNAME (e.g. a PAT-style credential used as username) is
+    // left in. storeData's top-level catch must not let that raw message become the DataStoreException's own
+    // message, since it feeds logs/error reporting.
+    @Test
+    public void test_storeData_fetchFailureMessageDoesNotLeakCredential() {
+        final DataStoreParams params = new DataStoreParams();
+        // Port 1 is a reserved/unassigned port that refuses connections immediately (no timeout wait).
+        params.put("uri", "https://leakyuser:leakysecret@127.0.0.1:1/nonexistent.git");
+        final List<String> urlList = new ArrayList<>();
+        try {
+            newCollectingDataStore(urlList).storeData(null, null, params, null, null);
+            fail("Expected DataStoreException");
+        } catch (final DataStoreException e) {
+            final String msg = e.getMessage();
+            assertFalse(msg != null && msg.contains("leakyuser"));
+            assertFalse(msg != null && msg.contains("leakysecret"));
+        }
+    }
+
+    // Fix #9: when the remote's advertised HEAD is NOT symbolic (some transports/servers don't advertise the
+    // git symref capability for HEAD), JGit's own CloneCommand#findBranchToCheckout still identifies a proper
+    // branch name by scanning refs/heads/* for one whose objectId matches HEAD's objectId, falling back to a
+    // bare SHA only if nothing matches. resolveDefaultBranch must replicate that scan instead of immediately
+    // returning the raw SHA -- a raw SHA in prev_source_ref would make isSameSource() flip-flop across runs
+    // with no actual branch/uri change (since the SHA moves as the branch advances).
+    @Test
+    public void test_findAdvertisedBranchByObjectId_matchesRefsHeads() throws Exception {
+        final GitDataStore dataStore = new GitDataStore();
+        final ObjectId targetId = ObjectId.fromString("0123456789abcdef0123456789abcdef01234567");
+        final ObjectId otherId = ObjectId.fromString("fedcba9876543210fedcba9876543210fedcba98");
+        final List<Ref> advertisedRefs = new ArrayList<>();
+        advertisedRefs.add(new FakeRef("refs/heads/develop", otherId));
+        advertisedRefs.add(new FakeRef("refs/heads/main", targetId));
+        advertisedRefs.add(new FakeRef("refs/tags/v1.0", targetId)); // a tag must NOT be treated as a branch
+
+        final String result = dataStore.findAdvertisedBranchByObjectId(advertisedRefs, targetId);
+
+        assertEquals("refs/heads/main", result);
+    }
+
+    @Test
+    public void test_findAdvertisedBranchByObjectId_noMatchReturnsNull() throws Exception {
+        final GitDataStore dataStore = new GitDataStore();
+        final ObjectId targetId = ObjectId.fromString("0123456789abcdef0123456789abcdef01234567");
+        final ObjectId otherId = ObjectId.fromString("fedcba9876543210fedcba9876543210fedcba98");
+        final List<Ref> advertisedRefs = new ArrayList<>();
+        advertisedRefs.add(new FakeRef("refs/heads/develop", otherId));
+
+        // Nothing under refs/heads/ matches the (detached/anonymous) target -- there is genuinely no branch
+        // name to report, so the caller must fall back to the raw SHA.
+        assertNull(dataStore.findAdvertisedBranchByObjectId(advertisedRefs, targetId));
+    }
+
+    @Test
+    public void test_findAdvertisedBranchByObjectId_nullHeadIdReturnsNull() throws Exception {
+        final GitDataStore dataStore = new GitDataStore();
+        final List<Ref> advertisedRefs = new ArrayList<>();
+        advertisedRefs.add(new FakeRef("refs/heads/main", ObjectId.fromString("0123456789abcdef0123456789abcdef01234567")));
+
+        assertNull(dataStore.findAdvertisedBranchByObjectId(advertisedRefs, null));
+    }
+
+    /** Minimal {@link Ref} test double: only getName()/getObjectId() are exercised by the code under test. */
+    private static final class FakeRef implements Ref {
+        private final String name;
+        private final ObjectId objectId;
+
+        FakeRef(final String name, final ObjectId objectId) {
+            this.name = name;
+            this.objectId = objectId;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean isSymbolic() {
+            return false;
+        }
+
+        @Override
+        public Ref getLeaf() {
+            return this;
+        }
+
+        @Override
+        public Ref getTarget() {
+            return this;
+        }
+
+        @Override
+        public ObjectId getObjectId() {
+            return objectId;
+        }
+
+        @Override
+        public ObjectId getPeeledObjectId() {
+            return null;
+        }
+
+        @Override
+        public boolean isPeeled() {
+            return false;
+        }
+
+        @Override
+        public Storage getStorage() {
+            return Storage.LOOSE;
+        }
+    }
+
     // Fix #8: a blank base_url must emit a WARN so operators know indexed URLs will be empty and delete/rename
     // tracking is skipped.
     @Test
@@ -541,15 +794,63 @@ public class GitDataStoreTest extends UnitDsTestCase {
         }
     }
 
-    // Fix #6: credentials embedded in a Git URI must be redacted before logging.
+    // Fix #6: credentials embedded in a Git URI must be redacted before logging. redactUrl() must be
+    // fail-CLOSED: java.net.URI is a strict RFC-3986 parser that throws on very common real-world Git
+    // credential syntax (scp-style user@host:path, unescaped '@'/'/' in passwords), and the old
+    // implementation returned the RAW url unchanged whenever that parser choked -- i.e. it failed OPEN.
     @Test
     public void test_redactUrl() {
         final GitDataStore dataStore = new GitDataStore();
+        // Normal case: URI authority with user:password -- must already work (regression check).
         assertEquals("https://github.com/codelibs/fess.git", dataStore.redactUrl("https://user:token@github.com/codelibs/fess.git"));
+
+        // scp-style remotes DO carry a credential-bearing user, and it must not survive redaction, even
+        // though java.net.URI cannot parse this syntax at all.
+        final String scpRedacted = dataStore.redactUrl("tokenuser@gitlab.example.com:group/project.git");
+        assertFalse(scpRedacted.contains("tokenuser"));
+        assertEquals("gitlab.example.com:group/project.git", scpRedacted);
+
+        // A password containing an unescaped '@' is valid in real-world Git credentials but is illegal
+        // per strict RFC-3986 userinfo syntax.
+        final String atInPassword = dataStore.redactUrl("https://user:p@ssw0rd@host/repo.git");
+        assertFalse(atInPassword.contains("p@ssw0rd"));
+        assertFalse(atInPassword.contains("ssw0rd"));
+
+        // A password containing an unescaped '/' likewise breaks strict URI parsing.
+        final String slashInPassword = dataStore.redactUrl("https://user:p/ssw0rd@host/repo.git");
+        assertFalse(slashInPassword.contains("p/ssw0rd"));
+        assertFalse(slashInPassword.contains("ssw0rd"));
+
+        // No credentials at all: must be returned unchanged (no regression).
         assertEquals("https://github.com/codelibs/fess.git", dataStore.redactUrl("https://github.com/codelibs/fess.git"));
-        // scp-style remotes have no URI authority component, so there is nothing to redact and they are returned as-is.
-        assertEquals("git@github.com:codelibs/fess.git", dataStore.redactUrl("git@github.com:codelibs/fess.git"));
+
+        // A conventional non-secret scp-style user (e.g. "git") is still stripped -- redactUrl cannot tell
+        // it apart from a credential-bearing user, and stripping it is harmless for a log/index value.
+        assertEquals("github.com:codelibs/fess.git", dataStore.redactUrl("git@github.com:codelibs/fess.git"));
+
+        // Blank/null input must be returned unchanged without throwing.
         assertEquals("", dataStore.redactUrl(""));
+        assertNull(dataStore.redactUrl(null));
+
+        // Bug fix (post-review): an uppercase/mixed-case scheme (e.g. "HTTPS://") makes JGit's URIish fail
+        // its normal FULL_URI parse (its internal SCHEME_P regex is lowercase-only) and silently fall through
+        // to the lenient LOCAL_FILE catch-all, which treats the entire input as an opaque local path --
+        // scheme/host/user/pass all come back null. Neither existing branch fires on that, so without a fix
+        // the raw, credential-bearing url would be returned completely unredacted.
+        final String upperScheme = dataStore.redactUrl("HTTPS://user:pass@Host/Repo.Git");
+        assertFalse(upperScheme.contains("pass"));
+
+        final String mixedScheme = dataStore.redactUrl("Https://user:token@host/repo.git");
+        assertFalse(mixedScheme.contains("token"));
+
+        // No credentials to strip: an uppercase-scheme url with no user-info must still come back essentially
+        // unchanged (not corrupted/emptied) even though it is routed through maskConservatively().
+        assertEquals("HTTPS://github.com/codelibs/fess.git", dataStore.redactUrl("HTTPS://github.com/codelibs/fess.git"));
+
+        // A genuine schemeless local filesystem path containing a literal '@' (e.g. in a directory name) has
+        // no scheme:// prefix at all, so it must NOT be routed through maskConservatively() and must come
+        // back completely unchanged -- there is no credential here to strip.
+        assertEquals("/home/user@company/repos/x.git", dataStore.redactUrl("/home/user@company/repos/x.git"));
     }
 
     // Fix #6 (residual): the "uri" placed into resultMap is DEBUG-logged and available to the script
@@ -848,75 +1149,115 @@ public class GitDataStoreTest extends UnitDsTestCase {
         }
     }
 
+    // These three tests exercise the REAL GitDataStore#getUrlFilter (no override): it looks up a UrlFilter
+    // component via ComponentUtil, so a RecordingUrlFilter test double is registered as that component
+    // (the same "fake the collaborator, exercise the real method" pattern runProcessFileCapturingResultMap
+    // uses for SystemHelper/CrawlerStatsHelper). This replaces the previous versions, which claimed to "call
+    // parent implementation to test it" but actually overrode getUrlFilter with a hand-rolled reimplementation
+    // that never called super, so the real method was never exercised and only assertNotNull(filter) was
+    // checked.
     @Test
     public void test_getUrlFilter_withIncludePattern() {
-        GitDataStore dataStore = new GitDataStore() {
-            @Override
-            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
-                // Call parent implementation to test it
-                UrlFilter filter = new MockUrlFilter();
-                final String include = paramMap.getAsString("include_pattern");
-                if (include != null && !include.isEmpty()) {
-                    filter.addInclude(include);
-                }
-                return filter;
-            }
-        };
+        final RecordingUrlFilter fakeFilter = new RecordingUrlFilter();
+        ComponentUtil.register(fakeFilter, UrlFilter.class.getCanonicalName());
+        final GitDataStore dataStore = new GitDataStore();
 
-        DataStoreParams params = new DataStoreParams();
+        final DataStoreParams params = new DataStoreParams();
         params.put("include_pattern", ".*\\.java");
 
-        UrlFilter filter = dataStore.getUrlFilter(params);
-        assertNotNull(filter);
+        final UrlFilter filter = dataStore.getUrlFilter(params);
+
+        assertSame(fakeFilter, filter);
+        assertEquals(1, fakeFilter.includePatterns.size());
+        assertTrue(filter.match("src/main/java/App.java"));
+        assertFalse(filter.match("README.md"));
     }
 
     @Test
     public void test_getUrlFilter_withExcludePattern() {
-        GitDataStore dataStore = new GitDataStore() {
-            @Override
-            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
-                // Call parent implementation to test it
-                UrlFilter filter = new MockUrlFilter();
-                final String exclude = paramMap.getAsString("exclude_pattern");
-                if (exclude != null && !exclude.isEmpty()) {
-                    filter.addExclude(exclude);
-                }
-                return filter;
-            }
-        };
+        final RecordingUrlFilter fakeFilter = new RecordingUrlFilter();
+        ComponentUtil.register(fakeFilter, UrlFilter.class.getCanonicalName());
+        final GitDataStore dataStore = new GitDataStore();
 
-        DataStoreParams params = new DataStoreParams();
+        final DataStoreParams params = new DataStoreParams();
         params.put("exclude_pattern", ".*\\.class");
 
-        UrlFilter filter = dataStore.getUrlFilter(params);
-        assertNotNull(filter);
+        final UrlFilter filter = dataStore.getUrlFilter(params);
+
+        assertSame(fakeFilter, filter);
+        assertEquals(1, fakeFilter.excludePatterns.size());
+        assertTrue(filter.match("App.java"));
+        assertFalse(filter.match("App.class"));
     }
 
     @Test
     public void test_getUrlFilter_withBothPatterns() {
-        GitDataStore dataStore = new GitDataStore() {
-            @Override
-            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
-                // Call parent implementation to test it
-                UrlFilter filter = new MockUrlFilter();
-                final String include = paramMap.getAsString("include_pattern");
-                if (include != null && !include.isEmpty()) {
-                    filter.addInclude(include);
-                }
-                final String exclude = paramMap.getAsString("exclude_pattern");
-                if (exclude != null && !exclude.isEmpty()) {
-                    filter.addExclude(exclude);
-                }
-                return filter;
-            }
-        };
+        final RecordingUrlFilter fakeFilter = new RecordingUrlFilter();
+        ComponentUtil.register(fakeFilter, UrlFilter.class.getCanonicalName());
+        final GitDataStore dataStore = new GitDataStore();
 
-        DataStoreParams params = new DataStoreParams();
+        final DataStoreParams params = new DataStoreParams();
         params.put("include_pattern", ".*\\.java");
         params.put("exclude_pattern", ".*Test\\.java");
 
-        UrlFilter filter = dataStore.getUrlFilter(params);
-        assertNotNull(filter);
+        final UrlFilter filter = dataStore.getUrlFilter(params);
+
+        assertSame(fakeFilter, filter);
+        assertEquals(1, fakeFilter.includePatterns.size());
+        assertEquals(1, fakeFilter.excludePatterns.size());
+        // Matches the include pattern and not the exclude pattern.
+        assertTrue(filter.match("src/main/java/App.java"));
+        // Matches the include pattern but is also excluded.
+        assertFalse(filter.match("src/main/java/AppTest.java"));
+        // Does not even match the include pattern.
+        assertFalse(filter.match("README.md"));
+    }
+
+    /**
+     * A {@link UrlFilter} test double that implements real include/exclude matching (mirroring
+     * {@code UrlFilterImpl#match}), used as the component {@link GitDataStore#getUrlFilter} looks up so the
+     * real method's wiring (addInclude/addExclude/init calls) is exercised without needing a full crawler
+     * container (the real {@code UrlFilterImpl} depends on a DI-injected {@code CrawlerContainer} that isn't
+     * available in this lightweight unit-test container).
+     */
+    private static final class RecordingUrlFilter implements UrlFilter {
+        private final List<java.util.regex.Pattern> includePatterns = new ArrayList<>();
+        private final List<java.util.regex.Pattern> excludePatterns = new ArrayList<>();
+
+        @Override
+        public void init(final String sessionId) {
+            // no-op: init() being called at all (without throwing) is implicitly verified by every test
+            // in this class reaching its assertions, since GitDataStore#getUrlFilter calls it unconditionally.
+        }
+
+        @Override
+        public boolean match(final String url) {
+            if (!includePatterns.isEmpty() && includePatterns.stream().noneMatch(p -> p.matcher(url).matches())) {
+                return false;
+            }
+            return excludePatterns.stream().noneMatch(p -> p.matcher(url).matches());
+        }
+
+        @Override
+        public void addInclude(final String urlPattern) {
+            includePatterns.add(java.util.regex.Pattern.compile(urlPattern));
+        }
+
+        @Override
+        public void addExclude(final String urlPattern) {
+            excludePatterns.add(java.util.regex.Pattern.compile(urlPattern));
+        }
+
+        @Override
+        public void processUrl(final String url) {
+            // no-op: not exercised by getUrlFilter.
+        }
+
+        @Override
+        public void clear() {
+            includePatterns.clear();
+            excludePatterns.clear();
+        }
     }
 
     private void deleteDirectory(File directory) {

--- a/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
@@ -236,7 +236,10 @@ public class GitDataStoreTest extends UnitDsTestCase {
                 dataStore.resolveToCommitId(repo, "ghost-branch", "refs/heads/ghost-branch");
                 fail("Expected DataStoreException");
             } catch (final DataStoreException e) {
-                assertTrue(e.getMessage().contains("Could not resolve commit_id 'ghost-branch'"));
+                // The message reports the ref that actually failed to resolve (the resolvedCommitId), and
+                // includes the originally configured commit_id for context.
+                assertTrue(e.getMessage().contains("Could not resolve commit_id 'refs/heads/ghost-branch'"));
+                assertTrue(e.getMessage().contains("configured commit_id was 'ghost-branch'"));
             }
         }
     }
@@ -350,6 +353,52 @@ public class GitDataStoreTest extends UnitDsTestCase {
             unreadableDir.setReadable(true);
             unreadableDir.setExecutable(true);
         }
+    }
+
+    // Fix #5: a first run killed mid-initialization can leave repository_path/.git as a partial skeleton.
+    // JGit's repository.create() writes .git/config LAST (cfg.save()) and refuses to re-run once config
+    // exists, so an interrupted create() leaves a .git that JGit cannot open (no object database / HEAD /
+    // config). The pre-existing check only skipped create() when .git already existed, so every subsequent
+    // run reused the unopenable partial repo and failed identically forever. The partial .git must be
+    // discarded and re-created so the next run succeeds -- the same "repeated-crawl failure" class the
+    // stale-.lock-file fix addresses, but for the narrower interrupted-initial-creation window.
+    @Test
+    public void test_storeData_recreatesIncompleteRepository() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createLocalRepo("main", files);
+
+        final File persistent = Files.createTempDirectory("fess-ds-git-persist-").toFile();
+        tempDirs.add(persistent);
+        // Simulate a create() killed mid-initialization: .git exists with only refs/ (no HEAD, no object
+        // database, no config). This is the hardest case for a heal -- a plain re-create() cannot repair it
+        // because refs.create() throws (mkdir on the already-existing refs/), so the partial .git must be
+        // deleted before re-creating.
+        final File refsDir = new File(persistent, ".git/refs");
+        assertTrue(refsDir.mkdirs());
+        assertFalse(new File(persistent, ".git/config").exists());
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remote.getAbsolutePath());
+        params.put("repository_path", persistent.getAbsolutePath());
+
+        // Run 1: the partial repo must be healed and the crawl must complete (pre-fix, this run throws).
+        final List<String> firstRun = new ArrayList<>();
+        newCollectingDataStore(firstRun).storeData(null, null, params, null, null);
+        assertTrue(firstRun.contains("a.txt"));
+        assertTrue(new File(persistent, ".git/config").exists());
+
+        // A sentinel written inside the now-valid .git proves run 2 does NOT re-delete it: because the
+        // remote is always reachable here, a wrongful re-delete would still re-fetch and collect a.txt, so
+        // "second run succeeds" alone cannot distinguish "left untouched" from "deleted and rebuilt".
+        final File sentinel = new File(persistent, ".git/fess-heal-sentinel");
+        assertTrue(sentinel.createNewFile());
+
+        // Run 2: the now-valid repository (config present) must be left untouched and reused, not re-deleted.
+        final List<String> secondRun = new ArrayList<>();
+        newCollectingDataStore(secondRun).storeData(null, null, params, null, null);
+        assertTrue(secondRun.contains("a.txt"));
+        assertTrue(sentinel.exists());
     }
 
     // Fix #4: an unchanged uri/branch (prev_source_ref matches) keeps using prev_commit_id for an incremental diff.
@@ -627,6 +676,14 @@ public class GitDataStoreTest extends UnitDsTestCase {
             final String msg = e.getMessage();
             assertFalse(msg != null && msg.contains("leakyuser"));
             assertFalse(msg != null && msg.contains("leakysecret"));
+            // The wrapped cause is what log4j2 prints as "Caused by:" and what failureUrlService persists, so
+            // its message must be scrubbed too. JGit's TransportException embeds the username (only the password
+            // is stripped) in its own getMessage(), so a raw cause here would still leak "leakyuser".
+            final Throwable cause = e.getCause();
+            assertNotNull(cause);
+            final String causeMsg = cause.getMessage();
+            assertFalse(causeMsg != null && causeMsg.contains("leakyuser"));
+            assertFalse(causeMsg != null && causeMsg.contains("leakysecret"));
         }
     }
 
@@ -851,6 +908,68 @@ public class GitDataStoreTest extends UnitDsTestCase {
         // no scheme:// prefix at all, so it must NOT be routed through maskConservatively() and must come
         // back completely unchanged -- there is no credential here to strip.
         assertEquals("/home/user@company/repos/x.git", dataStore.redactUrl("/home/user@company/repos/x.git"));
+    }
+
+    // Fix #10 (helper): redactCredentials scrubs a scheme://userinfo@ embedded anywhere in free-form text (e.g.
+    // a JGit exception message), leaving the scheme and the rest of the text intact; text with no embedded URL
+    // is returned unchanged.
+    @Test
+    public void test_redactCredentials() {
+        final GitDataStore dataStore = new GitDataStore();
+
+        // Username-only userinfo embedded mid-message (JGit strips the password but leaves the username).
+        assertEquals("https://127.0.0.1:1/nonexistent.git: Connection refused",
+                dataStore.redactCredentials("https://leakyuser@127.0.0.1:1/nonexistent.git: Connection refused"));
+
+        // Userinfo embedded with text BEFORE the URL: only the userinfo is stripped, surrounding text is kept.
+        assertEquals("failed to fetch https://host/repo.git for crawl",
+                dataStore.redactCredentials("failed to fetch https://tokenuser@host/repo.git for crawl"));
+
+        // Full user:pass userinfo embedded mid-message.
+        assertEquals("https://host/repo.git: auth failed", dataStore.redactCredentials("https://user:pass@host/repo.git: auth failed"));
+
+        // No embedded URL at all: returned completely unchanged.
+        assertEquals("plain error message with no url", dataStore.redactCredentials("plain error message with no url"));
+
+        // Blank/null returned unchanged without throwing.
+        assertEquals("", dataStore.redactCredentials(""));
+        assertNull(dataStore.redactCredentials(null));
+    }
+
+    // Fix #10 (helper): redactCredentialsInChain scrubs credentials from EVERY level of a cause chain (this is
+    // what log4j2 prints as "Caused by:" and what failureUrlService persists), returns the SAME instance when
+    // nothing needs redaction, and passes null through.
+    @Test
+    public void test_redactCredentialsInChain() {
+        final GitDataStore dataStore = new GitDataStore();
+
+        // Both levels carry an embedded credential; both must be scrubbed.
+        final Throwable leaky = new RuntimeException("outer https://leakyuser:leakysecret@host/repo.git: boom",
+                new IllegalStateException("inner https://leakyuser@host2/other.git: nope"));
+        final Throwable sanitized = dataStore.redactCredentialsInChain(leaky);
+        assertFalse(sanitized.getMessage().contains("leakyuser"));
+        assertFalse(sanitized.getMessage().contains("leakysecret"));
+        assertNotNull(sanitized.getCause());
+        assertFalse(sanitized.getCause().getMessage().contains("leakyuser"));
+        assertFalse(sanitized.getCause().getMessage().contains("leakysecret"));
+        // The replacement message embeds the original class name so logs still show the error type.
+        assertTrue(sanitized.getMessage().contains("java.lang.RuntimeException"));
+        // The original chain is left untouched (a sanitized copy is returned, not an in-place mutation).
+        assertTrue(leaky.getMessage().contains("leakyuser"));
+
+        // A leak only in the deeper cause must still be scrubbed, and the wrapper is rebuilt (different instance).
+        final Throwable cleanOuterLeakyInner =
+                new RuntimeException("clean outer message", new IllegalStateException("inner https://leakyuser@host/r.git: x"));
+        final Throwable sanitized2 = dataStore.redactCredentialsInChain(cleanOuterLeakyInner);
+        assertTrue(sanitized2 != cleanOuterLeakyInner);
+        assertFalse(sanitized2.getCause().getMessage().contains("leakyuser"));
+
+        // A chain with no embedded credentials anywhere is returned as the SAME instance (no pointless wrapping).
+        final Throwable clean = new RuntimeException("no url here", new IllegalStateException("still nothing"));
+        assertSame(clean, dataStore.redactCredentialsInChain(clean));
+
+        // Null passes through.
+        assertNull(dataStore.redactCredentialsInChain(null));
     }
 
     // Fix #6 (residual): the "uri" placed into resultMap is DEBUG-logged and available to the script

--- a/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
@@ -16,28 +16,55 @@
 package org.codelibs.fess.ds.git;
 
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.io.output.DeferredFileOutputStream;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.codelibs.fess.crawler.entity.ExtractData;
+import org.codelibs.fess.crawler.extractor.Extractor;
 import org.codelibs.fess.crawler.filter.UrlFilter;
 import org.codelibs.fess.ds.callback.IndexUpdateCallback;
 import org.codelibs.fess.entity.DataStoreParams;
 import org.codelibs.fess.exception.DataStoreException;
+import org.codelibs.fess.helper.CrawlerStatsHelper;
+import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.ds.git.UnitDsTestCase;
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 public class GitDataStoreTest extends UnitDsTestCase {
+
+    private final List<File> tempDirs = new ArrayList<>();
 
     @Override
     protected String prepareConfigFile() {
@@ -56,10 +83,47 @@ public class GitDataStoreTest extends UnitDsTestCase {
 
     @Override
     public void tearDown(TestInfo testInfo) throws Exception {
+        for (final File dir : tempDirs) {
+            deleteDirectory(dir);
+        }
+        tempDirs.clear();
         ComponentUtil.setFessConfig(null);
         super.tearDown(testInfo);
     }
 
+    /**
+     * Creates a local scratch Git repository with the given initial branch and file contents,
+     * committing all files in a single commit. The returned directory can be used as a Git {@code uri}.
+     */
+    private File createLocalRepo(final String initialBranch, final Map<String, String> files) throws Exception {
+        final File dir = Files.createTempDirectory("fess-ds-git-src-").toFile();
+        tempDirs.add(dir);
+        try (Git git = Git.init().setInitialBranch(initialBranch).setDirectory(dir).call()) {
+            addAndCommit(git, dir, files, "initial commit");
+        }
+        return dir;
+    }
+
+    /** Writes the given files into the repository working tree and creates a single commit. */
+    private RevCommit addAndCommit(final Git git, final File dir, final Map<String, String> files, final String message) throws Exception {
+        for (final Map.Entry<String, String> entry : files.entrySet()) {
+            final File f = new File(dir, entry.getKey());
+            if (f.getParentFile() != null) {
+                f.getParentFile().mkdirs();
+            }
+            try (FileOutputStream out = new FileOutputStream(f)) {
+                out.write(entry.getValue().getBytes());
+            }
+            git.add().addFilepattern(entry.getKey()).call();
+        }
+        return git.commit()
+                .setMessage(message)
+                .setAuthor("Test Author", "author@example.com")
+                .setCommitter("Test Committer", "committer@example.com")
+                .call();
+    }
+
+    @Test
     public void test_storeData() {
         DataStoreParams params = new DataStoreParams();
         params.put("uri", "https://github.com/codelibs/fess-ds-git.git");
@@ -87,6 +151,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertTrue(urlList.size() > 0);
     }
 
+    @Test
     public void test_storeData_withoutUri() {
         DataStoreParams params = new DataStoreParams();
         GitDataStore dataStore = new GitDataStore();
@@ -98,6 +163,528 @@ public class GitDataStoreTest extends UnitDsTestCase {
         }
     }
 
+    // Fix #2: the remote's actual default branch (e.g. "main") must be resolved and checked out,
+    // instead of blindly trusting the JGit-default local "HEAD" (refs/heads/master), which would
+    // otherwise throw RefNotFoundException/NoHeadException on every run.
+    @Test
+    public void test_storeData_defaultBranchMain() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("README.md", "hello world");
+        files.put("pom.xml", "<project/>");
+        final File remote = createLocalRepo("main", files);
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remote.getAbsolutePath());
+        final List<String> urlList = new ArrayList<>();
+        final GitDataStore dataStore = new GitDataStore() {
+            @Override
+            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
+                return new MockUrlFilter();
+            }
+
+            @Override
+            protected void processFile(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
+                    final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final Map<String, Object> configMap) {
+                urlList.add(((DiffEntry) configMap.get(DIFF_ENTRY)).getNewPath());
+            }
+        };
+        dataStore.storeData(null, null, params, null, null);
+
+        assertTrue(urlList.contains("README.md"));
+        assertTrue(urlList.contains("pom.xml"));
+    }
+
+    /** Creates a local repo on branch "main" with two commits; returns [repoDir, firstCommitSha]. HEAD points at the second commit. */
+    private String[] createTwoCommitRepo() throws Exception {
+        final File dir = Files.createTempDirectory("fess-ds-git-src-").toFile();
+        tempDirs.add(dir);
+        final String firstCommit;
+        try (Git git = Git.init().setInitialBranch("main").setDirectory(dir).call()) {
+            final Map<String, String> first = new LinkedHashMap<>();
+            first.put("a.txt", "first");
+            firstCommit = addAndCommit(git, dir, first, "c1").name();
+            final Map<String, String> second = new LinkedHashMap<>();
+            second.put("b.txt", "second");
+            addAndCommit(git, dir, second, "c2");
+        }
+        return new String[] { dir.getAbsolutePath(), firstCommit };
+    }
+
+    private GitDataStore newCollectingDataStore(final List<String> urlList) {
+        return new GitDataStore() {
+            @Override
+            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
+                return new MockUrlFilter();
+            }
+
+            @Override
+            protected void processFile(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
+                    final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final Map<String, Object> configMap) {
+                urlList.add(((DiffEntry) configMap.get(DIFF_ENTRY)).getNewPath());
+            }
+        };
+    }
+
+    // Fix #1: an unresolvable commit_id must fail fast with a clear message, before any diff/delete can run.
+    @Test
+    public void test_resolveToCommitId() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File repoDir = createLocalRepo("main", files);
+        final GitDataStore dataStore = new GitDataStore();
+        try (Git git = Git.open(repoDir)) {
+            final Repository repo = git.getRepository();
+            assertNotNull(dataStore.resolveToCommitId(repo, "HEAD", "refs/heads/main"));
+            try {
+                dataStore.resolveToCommitId(repo, "ghost-branch", "refs/heads/ghost-branch");
+                fail("Expected DataStoreException");
+            } catch (final DataStoreException e) {
+                assertTrue(e.getMessage().contains("Could not resolve commit_id 'ghost-branch'"));
+            }
+        }
+    }
+
+    // Fix #3: a stale JGit lock file left by a killed crawl under a persistent repository_path must be
+    // removed automatically so the next run succeeds instead of failing identically forever.
+    @Test
+    public void test_storeData_removesStaleLockFile() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createLocalRepo("main", files);
+
+        final File persistent = Files.createTempDirectory("fess-ds-git-persist-").toFile();
+        tempDirs.add(persistent);
+        try (Repository repo = FileRepositoryBuilder.create(new File(persistent, ".git"))) {
+            repo.create();
+        }
+        final File refsHeads = new File(persistent, ".git/refs/heads");
+        refsHeads.mkdirs();
+        final File staleLock = new File(refsHeads, "main.lock");
+        assertTrue(staleLock.createNewFile());
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remote.getAbsolutePath());
+        params.put("repository_path", persistent.getAbsolutePath());
+        final List<String> urlList = new ArrayList<>();
+        newCollectingDataStore(urlList).storeData(null, null, params, null, null);
+
+        assertTrue(urlList.contains("a.txt"));
+        assertFalse(staleLock.exists());
+    }
+
+    // Fix #3: while another crawl genuinely holds the advisory lock, a concurrent run must fail fast with a
+    // clear message rather than corrupting the shared repository_path.
+    @Test
+    public void test_storeData_concurrentLockFailsFast() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createLocalRepo("main", files);
+
+        final File persistent = Files.createTempDirectory("fess-ds-git-persist-").toFile();
+        tempDirs.add(persistent);
+        final File marker = new File(persistent, ".fess-ds-git.lock");
+        try (FileChannel channel = FileChannel.open(marker.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                FileLock held = channel.lock()) {
+            final DataStoreParams params = new DataStoreParams();
+            params.put("uri", remote.getAbsolutePath());
+            params.put("repository_path", persistent.getAbsolutePath());
+            final List<String> urlList = new ArrayList<>();
+            try {
+                newCollectingDataStore(urlList).storeData(null, null, params, null, null);
+                fail("Expected DataStoreException");
+            } catch (final DataStoreException e) {
+                final String msg = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+                assertTrue(msg != null && msg.contains("Another crawl appears to be using repository_path"));
+            }
+        }
+    }
+
+    // Fix #4: an unchanged uri/branch (prev_source_ref matches) keeps using prev_commit_id for an incremental diff.
+    @Test
+    public void test_storeData_incrementalWhenSourceUnchanged() throws Exception {
+        final String[] repo = createTwoCommitRepo();
+        final String remotePath = repo[0];
+        final String firstCommit = repo[1];
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remotePath);
+        params.put("prev_commit_id", firstCommit);
+        params.put("prev_source_ref", remotePath + "#refs/heads/main");
+        final List<String> urlList = new ArrayList<>();
+        newCollectingDataStore(urlList).storeData(null, null, params, null, null);
+
+        assertTrue(urlList.contains("b.txt"));
+        assertFalse(urlList.contains("a.txt"));
+    }
+
+    // Fix #4: a changed uri (prev_source_ref no longer matches) ignores the stale prev_commit_id and does a full reindex.
+    @Test
+    public void test_storeData_fullReindexWhenSourceChanged() throws Exception {
+        final String[] repo = createTwoCommitRepo();
+        final String remotePath = repo[0];
+        final String firstCommit = repo[1];
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remotePath);
+        params.put("prev_commit_id", firstCommit);
+        params.put("prev_source_ref", "https://other.example.com/repo.git#refs/heads/main");
+        final List<String> urlList = new ArrayList<>();
+        newCollectingDataStore(urlList).storeData(null, null, params, null, null);
+
+        assertTrue(urlList.contains("a.txt"));
+        assertTrue(urlList.contains("b.txt"));
+    }
+
+    // Fix #4 (predicate): isSameSource trusts prev_commit_id only when the recorded source ref matches;
+    // a blank recorded ref (pre-fix configs / manual prev_commit_id) is treated as a match for compatibility.
+    @Test
+    public void test_isSameSource() {
+        final GitDataStore dataStore = new GitDataStore();
+        assertTrue(dataStore.isSameSource(null, "uri#refs/heads/main"));
+        assertTrue(dataStore.isSameSource("", "uri#refs/heads/main"));
+        assertTrue(dataStore.isSameSource("  ", "uri#refs/heads/main"));
+        assertTrue(dataStore.isSameSource("uri#refs/heads/main", "uri#refs/heads/main"));
+        assertFalse(dataStore.isSameSource("uri#refs/heads/dev", "uri#refs/heads/main"));
+        assertFalse(dataStore.isSameSource("other#refs/heads/main", "uri#refs/heads/main"));
+    }
+
+    // Fix #4 (write-back): the persisted prev_source_ref must be BYTE-IDENTICAL to the currentSourceRef the
+    // read side (test_storeData_incrementalWhenSourceUnchanged hardcodes "<uri>#refs/heads/main") later compares
+    // against; otherwise the two halves each pass their own tests while incremental detection silently breaks.
+    // This also exercises the `if (dataConfig != null) updateDataConfig(...)` branch that the null-dataConfig
+    // storeData tests skip entirely (DataConfigBhv is never touched because updateDataConfig is overridden).
+    @Test
+    public void test_storeData_persistedSourceRefMatchesReadSide() throws Exception {
+        final String[] repo = createTwoCommitRepo();
+        final String remotePath = repo[0];
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remotePath);
+
+        final AtomicReference<String> capturedSourceRef = new AtomicReference<>();
+        final AtomicReference<ObjectId> capturedCommitId = new AtomicReference<>();
+        final GitDataStore dataStore = new GitDataStore() {
+            @Override
+            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
+                return new MockUrlFilter();
+            }
+
+            @Override
+            protected void processFile(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
+                    final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final Map<String, Object> configMap) {
+                // no-op: this test only cares about the write-back of prev_source_ref.
+            }
+
+            @Override
+            protected void updateDataConfig(final DataConfig dc, final String sourceRef, final ObjectId toCommitId) {
+                capturedSourceRef.set(sourceRef);
+                capturedCommitId.set(toCommitId);
+            }
+        };
+        dataStore.storeData(new DataConfig(), null, params, null, null);
+
+        assertEquals(remotePath + "#refs/heads/main", capturedSourceRef.get());
+        assertNotNull(capturedCommitId.get());
+    }
+
+    // Fix #4 (write-back): first-ever persist appends both prev_commit_id and prev_source_ref, preserving order.
+    @Test
+    public void test_buildHandlerParameter_appendsWhenAbsent() {
+        final GitDataStore dataStore = new GitDataStore();
+        final Map<String, String> handlerParameterMap = new LinkedHashMap<>();
+        handlerParameterMap.put("uri", "https://example.com/repo.git");
+        handlerParameterMap.put("base_url", "https://example.com/repo/blob/main/");
+
+        final String result =
+                dataStore.buildHandlerParameter(handlerParameterMap, "abc123", "https://example.com/repo.git#refs/heads/main");
+
+        assertEquals("uri=https://example.com/repo.git\n" + "base_url=https://example.com/repo/blob/main/\n" + "prev_commit_id=abc123\n"
+                + "prev_source_ref=https://example.com/repo.git#refs/heads/main", result);
+    }
+
+    // Fix #4 (write-back): a repeat run updates existing prev_commit_id/prev_source_ref in place, never duplicating.
+    @Test
+    public void test_buildHandlerParameter_updatesInPlace() {
+        final GitDataStore dataStore = new GitDataStore();
+        final Map<String, String> handlerParameterMap = new LinkedHashMap<>();
+        handlerParameterMap.put("uri", "https://example.com/repo.git");
+        handlerParameterMap.put("prev_commit_id", "OLD_COMMIT");
+        handlerParameterMap.put("prev_source_ref", "https://example.com/repo.git#refs/heads/OLD");
+
+        final String result =
+                dataStore.buildHandlerParameter(handlerParameterMap, "NEW_COMMIT", "https://example.com/repo.git#refs/heads/main");
+
+        assertEquals("uri=https://example.com/repo.git\n" + "prev_commit_id=NEW_COMMIT\n"
+                + "prev_source_ref=https://example.com/repo.git#refs/heads/main", result);
+        assertEquals(1L, result.lines().filter(l -> l.startsWith("prev_commit_id=")).count());
+        assertEquals(1L, result.lines().filter(l -> l.startsWith("prev_source_ref=")).count());
+    }
+
+    // Fix #4 (write-back): the backward-compat upgrade path -- a pre-fix config has prev_commit_id but no
+    // prev_source_ref -- must update prev_commit_id in place AND append prev_source_ref (no duplication).
+    @Test
+    public void test_buildHandlerParameter_mixedUpgrade() {
+        final GitDataStore dataStore = new GitDataStore();
+        final Map<String, String> handlerParameterMap = new LinkedHashMap<>();
+        handlerParameterMap.put("uri", "https://example.com/repo.git");
+        handlerParameterMap.put("prev_commit_id", "OLD_COMMIT");
+
+        final String result =
+                dataStore.buildHandlerParameter(handlerParameterMap, "NEW_COMMIT", "https://example.com/repo.git#refs/heads/main");
+
+        assertEquals("uri=https://example.com/repo.git\n" + "prev_commit_id=NEW_COMMIT\n"
+                + "prev_source_ref=https://example.com/repo.git#refs/heads/main", result);
+        assertEquals(1L, result.lines().filter(l -> l.startsWith("prev_commit_id=")).count());
+    }
+
+    // Fix #4 (write-back): the persisted string must round-trip back through DataConfig.getHandlerParameterMap()
+    // (ParameterUtil.parse) with the embedded '#' preserved, so a later run reads back the exact source ref it
+    // wrote and isSameSource returns true. A fresh DataConfig is used because setHandlerParameter does NOT reset
+    // the lazily-cached handlerParameterMap.
+    @Test
+    public void test_buildHandlerParameter_roundTripsThroughDataConfig() {
+        final GitDataStore dataStore = new GitDataStore();
+        final String sourceRef = "https://github.com/codelibs/fess.git#refs/heads/main";
+        final Map<String, String> handlerParameterMap = new LinkedHashMap<>();
+        handlerParameterMap.put("uri", "https://github.com/codelibs/fess.git");
+
+        final String result = dataStore.buildHandlerParameter(handlerParameterMap, "abc123", sourceRef);
+
+        final DataConfig dataConfig = new DataConfig();
+        dataConfig.setHandlerParameter(result);
+        final Map<String, String> parsed = dataConfig.getHandlerParameterMap();
+        assertEquals("abc123", parsed.get("prev_commit_id"));
+        assertEquals(sourceRef, parsed.get("prev_source_ref"));
+        // The value read back is exactly what the read side compares against.
+        assertTrue(dataStore.isSameSource(parsed.get("prev_source_ref"), sourceRef));
+    }
+
+    // Fix #2 (no regression): an explicitly configured commit_id/branch (non-HEAD) bypasses remote HEAD
+    // resolution entirely and is returned unchanged, so the common non-default case behaves exactly as before.
+    @Test
+    public void test_resolveDefaultBranch_explicitCommitIdBypass() throws Exception {
+        final GitDataStore dataStore = new GitDataStore();
+        // The early return fires before fetchResult/repository are touched, so null args are safe here.
+        assertEquals("refs/heads/dev", dataStore.resolveDefaultBranch(null, null, "refs/heads/dev"));
+        assertEquals("v1.2.3", dataStore.resolveDefaultBranch(null, null, "v1.2.3"));
+        assertEquals("0123456789abcdef0123456789abcdef01234567",
+                dataStore.resolveDefaultBranch(null, null, "0123456789abcdef0123456789abcdef01234567"));
+    }
+
+    // Fix #8: a blank base_url must emit a WARN so operators know indexed URLs will be empty and delete/rename
+    // tracking is skipped.
+    @Test
+    public void test_storeData_warnsWhenBaseUrlBlank() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createLocalRepo("main", files);
+
+        final String loggerName = GitDataStore.class.getName();
+        final LoggerContext ctx = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
+        final Configuration cfg = ctx.getConfiguration();
+        final LoggerConfig loggerCfg = cfg.getLoggerConfig(loggerName);
+        final Level originalLevel = loggerCfg.getLevel();
+        final List<LogEvent> captured = new ArrayList<>();
+        final AbstractAppender listAppender =
+                new AbstractAppender("git-ds-test-appender", null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
+                    @Override
+                    public void append(final LogEvent event) {
+                        if (event.getLevel().isMoreSpecificThan(Level.WARN)) {
+                            captured.add(event.toImmutable());
+                        }
+                    }
+                };
+        listAppender.start();
+        loggerCfg.addAppender(listAppender, Level.WARN, null);
+        loggerCfg.setLevel(Level.WARN);
+        ctx.updateLoggers();
+        try {
+            final DataStoreParams params = new DataStoreParams();
+            params.put("uri", remote.getAbsolutePath());
+            // base_url intentionally omitted so it is blank.
+            final List<String> urlList = new ArrayList<>();
+            newCollectingDataStore(urlList).storeData(null, null, params, null, null);
+
+            final long warnCount = captured.stream()
+                    .filter(e -> loggerName.equals(e.getLoggerName()))
+                    .filter(e -> Level.WARN.equals(e.getLevel()))
+                    .filter(e -> {
+                        final String msg = e.getMessage().getFormattedMessage();
+                        return msg != null && msg.contains("base_url is blank");
+                    })
+                    .count();
+            assertEquals(1L, warnCount);
+        } finally {
+            loggerCfg.removeAppender("git-ds-test-appender");
+            loggerCfg.setLevel(originalLevel);
+            ctx.updateLoggers();
+            listAppender.stop();
+        }
+    }
+
+    // Fix #5: getRevCommit closes the RevWalk internally; author/committer/timestamp must remain readable afterward.
+    @Test
+    public void test_getRevCommit_readableAfterWalkClosed() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "content");
+        final File repoDir = createLocalRepo("main", files);
+        final GitDataStore dataStore = new GitDataStore();
+        try (Git git = Git.open(repoDir)) {
+            final Map<String, Object> configMap = new HashMap<>();
+            configMap.put("git", git);
+            configMap.put("current_commit_id", git.getRepository().resolve("refs/heads/main"));
+            final RevCommit commit = dataStore.getRevCommit(configMap, "a.txt");
+            assertNotNull(commit.getAuthorIdent());
+            assertEquals("Test Author", commit.getAuthorIdent().getName());
+            assertEquals("Test Committer", commit.getCommitterIdent().getName());
+            assertTrue(commit.getCommitTime() > 0);
+        }
+    }
+
+    // Fix #6: credentials embedded in a Git URI must be redacted before logging.
+    @Test
+    public void test_redactUrl() {
+        final GitDataStore dataStore = new GitDataStore();
+        assertEquals("https://github.com/codelibs/fess.git", dataStore.redactUrl("https://user:token@github.com/codelibs/fess.git"));
+        assertEquals("https://github.com/codelibs/fess.git", dataStore.redactUrl("https://github.com/codelibs/fess.git"));
+        // scp-style remotes have no URI authority component, so there is nothing to redact and they are returned as-is.
+        assertEquals("git@github.com:codelibs/fess.git", dataStore.redactUrl("git@github.com:codelibs/fess.git"));
+        assertEquals("", dataStore.redactUrl(""));
+    }
+
+    // Fix #6 (residual): the "uri" placed into resultMap is DEBUG-logged and available to the script
+    // mapping (so it can be indexed), therefore it must have any embedded credentials stripped. The raw
+    // credential-bearing uri kept in configMap (used earlier by git fetch/checkout) must stay untouched.
+    @Test
+    public void test_processFile_redactsUriInResultMap() throws Exception {
+        final String credentialUri = "https://user:token@github.com/codelibs/fess.git";
+        final AtomicReference<Map<String, Object>> capturedResultMap = new AtomicReference<>();
+        final DataStoreParams paramMap = new DataStoreParams();
+
+        final Map<String, Object> configMap = runProcessFileCapturingResultMap(credentialUri, paramMap, capturedResultMap);
+
+        final Map<String, Object> resultMap = capturedResultMap.get();
+        assertNotNull(resultMap);
+        // The logged/indexed uri has its user:token@ credentials stripped, keeping host and path.
+        assertEquals("https://github.com/codelibs/fess.git", resultMap.get("uri"));
+        assertFalse(resultMap.get("uri").toString().contains("token"));
+        // The raw uri that git fetch/checkout rely on is left untouched in configMap.
+        assertEquals(credentialUri, configMap.get("uri"));
+    }
+
+    // Fix #7: username/password passed as data-store params must be stripped from resultMap so they are
+    // never surfaced to the script mapping / indexed document (defense-in-depth alongside uri redaction).
+    @Test
+    public void test_processFile_stripsCredentialsFromResultMap() throws Exception {
+        final String uri = "https://github.com/codelibs/fess.git";
+        final AtomicReference<Map<String, Object>> capturedResultMap = new AtomicReference<>();
+        final DataStoreParams paramMap = new DataStoreParams();
+        paramMap.put("username", "alice");
+        paramMap.put("password", "s3cr3t-token");
+
+        runProcessFileCapturingResultMap(uri, paramMap, capturedResultMap);
+
+        final Map<String, Object> resultMap = capturedResultMap.get();
+        assertNotNull(resultMap);
+        // The credential keys themselves must be absent.
+        assertFalse(resultMap.containsKey("username"));
+        assertFalse(resultMap.containsKey("password"));
+        // And neither credential value must leak in under any other key.
+        assertFalse(resultMap.values().stream().anyMatch(v -> "alice".equals(v)));
+        assertFalse(resultMap.values().stream().anyMatch(v -> "s3cr3t-token".equals(v)));
+    }
+
+    /**
+     * Drives {@link GitDataStore#processFile} against a fresh single-file local repository, capturing the
+     * {@code resultMap} handed to {@code convertValue}. The credential-bearing {@code uri} is deliberately
+     * decoupled from the local repository backing REPOSITORY/DIFF_ENTRY, exactly as in production (the uri
+     * string and the temp clone are separate objects); driving through {@code storeData} would instead force
+     * the fetch uri to equal the resultMap uri. Returns the {@code configMap} so callers can assert the raw
+     * uri kept for git fetch/checkout was left untouched.
+     */
+    private Map<String, Object> runProcessFileCapturingResultMap(final String uri, final DataStoreParams paramMap,
+            final AtomicReference<Map<String, Object>> capturedResultMap) throws Exception {
+        // The real processFile pipeline uses CrawlerStatsHelper (which in turn uses SystemHelper); register
+        // initialized instances so it can run inside this unit-test container.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final CrawlerStatsHelper crawlerStatsHelper = new CrawlerStatsHelper();
+        crawlerStatsHelper.init();
+        ComponentUtil.register(crawlerStatsHelper, "crawlerStatsHelper");
+
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "hello world");
+        final File repoDir = createLocalRepo("main", files);
+
+        try (Git git = Git.open(repoDir)) {
+            final Repository repository = git.getRepository();
+            final ObjectId head = repository.resolve("refs/heads/main");
+
+            final DiffEntry addEntry;
+            try (DiffFormatter diffFormatter = new DiffFormatter(null)) {
+                diffFormatter.setRepository(repository);
+                // fromCommitId == null diffs against the empty tree, so every committed file appears as ADD.
+                addEntry = diffFormatter.scan(null, head).get(0);
+            }
+
+            final Map<String, Object> configMap = new HashMap<>();
+            configMap.put("uri", uri);
+            configMap.put("diff_entry", addEntry);
+            configMap.put("repository", repository);
+            configMap.put("git", git);
+            configMap.put("current_commit_id", head);
+            configMap.put("max_size", 10000000L);
+            configMap.put("cache_threshold", 1000000);
+            configMap.put("read_interval", 0L);
+
+            final GitDataStore dataStore = new GitDataStore() {
+                @Override
+                protected String getMimeType(final String filename, final DeferredFileOutputStream out) {
+                    return "text/plain";
+                }
+
+                @Override
+                protected Extractor getExtractor(final String mimeType, final Map<String, Object> configMap) {
+                    return (in, params) -> new ExtractData("dummy content");
+                }
+
+                @Override
+                protected Object convertValue(final String scriptType, final String template, final Map<String, Object> resultMap) {
+                    capturedResultMap.set(resultMap);
+                    return null;
+                }
+            };
+
+            final IndexUpdateCallback callback = new IndexUpdateCallback() {
+                @Override
+                public void store(final DataStoreParams paramMap, final Map<String, Object> dataMap) {
+                    // no-op
+                }
+
+                @Override
+                public long getExecuteTime() {
+                    return 0;
+                }
+
+                @Override
+                public long getDocumentSize() {
+                    return 0;
+                }
+
+                @Override
+                public void commit() {
+                    // no-op
+                }
+            };
+
+            final Map<String, String> scriptMap = new HashMap<>();
+            scriptMap.put("url", "url"); // one entry so convertValue is invoked with the resultMap
+
+            dataStore.processFile(null, callback, paramMap, scriptMap, new HashMap<>(), configMap);
+            return configMap;
+        }
+    }
+
+    @Test
     public void test_getFileName() {
         GitDataStore dataStore = new GitDataStore();
 
@@ -115,6 +702,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertEquals("", dataStore.getFileName("path/to/"));
     }
 
+    @Test
     public void test_getUrl_withBaseUrl() {
         GitDataStore dataStore = new GitDataStore();
         DataStoreParams params = new DataStoreParams();
@@ -124,6 +712,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertEquals("https://github.com/user/repo/blob/main/src/main/java/Test.java", url);
     }
 
+    @Test
     public void test_getUrl_withoutBaseUrl() {
         GitDataStore dataStore = new GitDataStore();
         DataStoreParams params = new DataStoreParams();
@@ -132,6 +721,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertEquals("", url);
     }
 
+    @Test
     public void test_getUrl_withEmptyBaseUrl() {
         GitDataStore dataStore = new GitDataStore();
         DataStoreParams params = new DataStoreParams();
@@ -141,6 +731,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertEquals("", url);
     }
 
+    @Test
     public void test_createConfigMap_withDefaultValues() {
         GitDataStore dataStore = new GitDataStore();
         DataStoreParams params = new DataStoreParams();
@@ -162,6 +753,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         }
     }
 
+    @Test
     public void test_createConfigMap_withCustomValues() {
         GitDataStore dataStore = new GitDataStore();
         DataStoreParams params = new DataStoreParams();
@@ -185,6 +777,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         }
     }
 
+    @Test
     public void test_createConfigMap_withExtractors() {
         GitDataStore dataStore = new GitDataStore();
         DataStoreParams params = new DataStoreParams();
@@ -202,6 +795,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         }
     }
 
+    @Test
     public void test_getContentInputStream_inMemory() throws IOException {
         GitDataStore dataStore = new GitDataStore();
 
@@ -224,6 +818,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         is.close();
     }
 
+    @Test
     public void test_getContentInputStream_onDisk() throws IOException {
         GitDataStore dataStore = new GitDataStore();
 
@@ -253,6 +848,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         }
     }
 
+    @Test
     public void test_getUrlFilter_withIncludePattern() {
         GitDataStore dataStore = new GitDataStore() {
             @Override
@@ -274,6 +870,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertNotNull(filter);
     }
 
+    @Test
     public void test_getUrlFilter_withExcludePattern() {
         GitDataStore dataStore = new GitDataStore() {
             @Override
@@ -295,6 +892,7 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertNotNull(filter);
     }
 
+    @Test
     public void test_getUrlFilter_withBothPatterns() {
         GitDataStore dataStore = new GitDataStore() {
             @Override

--- a/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
@@ -355,6 +355,52 @@ public class GitDataStoreTest extends UnitDsTestCase {
         }
     }
 
+    // Fix (this review): deleteStaleLockFiles() catches only the IOException/UncheckedIOException family that
+    // Files.walk() can throw. Any OTHER throwable it raises (e.g. a SecurityException under a SecurityManager)
+    // would, pre-fix, escape lockRepositoryPath() -- which has already stored the just-acquired advisory lock
+    // in the caller's map and has no surrounding try/catch in storeData() -- and leak that FileLock for the
+    // life of the JVM, blocking every future crawl of this repository_path. lockRepositoryPath() must release
+    // the lock on ANY throw from the stale-lock scan, not just on the IOException family.
+    @Test
+    public void test_storeData_staleLockScanRuntimeErrorDoesNotLeakLock() throws Exception {
+        final File persistent = Files.createTempDirectory("fess-ds-git-persist-").toFile();
+        tempDirs.add(persistent);
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", "https://example.invalid/repo.git"); // never reached: the scan fails first
+        params.put("repository_path", persistent.getAbsolutePath());
+
+        final GitDataStore dataStore = new GitDataStore() {
+            @Override
+            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
+                return new MockUrlFilter();
+            }
+
+            @Override
+            protected void deleteStaleLockFiles(final File gitDir) {
+                // A non-IOException throwable from the scan (the IOException family is already handled inside
+                // deleteStaleLockFiles); this stands in for e.g. a SecurityException.
+                throw new IllegalStateException("simulated non-IOException scan failure");
+            }
+        };
+
+        try {
+            dataStore.storeData(null, null, params, null, null);
+            fail("Expected IllegalStateException");
+        } catch (final IllegalStateException e) {
+            assertEquals("simulated non-IOException scan failure", e.getMessage());
+        }
+
+        // The advisory lock must have been released despite the non-IOException scan failure: a fresh,
+        // independent lock attempt on the same marker (from this same JVM) must succeed. Pre-fix, the lock
+        // leaks and tryLock() would throw OverlappingFileLockException / return null.
+        final File marker = new File(persistent, ".fess-ds-git.lock");
+        try (FileChannel channel = FileChannel.open(marker.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                FileLock lock = channel.tryLock()) {
+            assertNotNull(lock);
+        }
+    }
+
     // Fix #5: a first run killed mid-initialization can leave repository_path/.git as a partial skeleton.
     // JGit's repository.create() writes .git/config LAST (cfg.save()) and refuses to re-run once config
     // exists, so an interrupted create() leaves a .git that JGit cannot open (no object database / HEAD /


### PR DESCRIPTION
## Summary

While investigating reports that repeated crawls of the same Git data-store
config sometimes fail after the first successful run, this PR fixes several
related reliability, correctness, and security issues in `GitDataStore`:

- **Data loss (critical)**: `commit_id` resolution was never null-checked.
  If it became unresolvable on a repeat run (deleted/renamed branch, typo),
  JGit's diff treated the missing target as an empty tree, marking every
  previously indexed file as deleted — and only *then* crashing with an
  NPE. Now fails fast with a clear error before any deletion can happen.
- **Checkout failures on non-`master` default branches**: the default
  `commit_id="HEAD"` never actually resolved against the remote's real
  default branch, so any repository defaulting to `main` (GitHub's default
  since 2020) failed checkout every run. Now resolves the actual default
  branch from the fetch result.
- **Repeated-crawl failures on a persistent `repository_path`**: a crawl
  killed mid-fetch (e.g. on timeout) could leave stale JGit lock files
  under `.git`, causing every subsequent run to fail identically until
  manually cleaned up. Now guards persistent paths with an OS-level
  advisory lock (auto-released by the OS even if the process is killed)
  and removes stale lock files once the lock is confirmed held.
- **Stale incremental state**: changing `uri`/branch on an existing
  DataConfig previously caused diffing across unrelated histories. Now
  detects the change and falls back to a full reindex.
- **Resource leak**: a `RevWalk` opened per changed file was never closed.
- **Credential leakage**: `username`/`password` and any userinfo embedded
  in the repository URI could reach debug logs, warn logs, failure-url
  records, and persisted data-config parameters. All of these are now
  redacted/stripped; the raw values are still used for the actual Git
  authentication.
- Warns once when `base_url` is unset (indexed URLs collide and
  delete/rename tracking is silently disabled otherwise).
- The existing test suite was silently executing 0 tests (missing JUnit 5
  `@Test` annotations after a framework migration) — fixed, plus added
  regression tests for everything above.
- Documented `repository_path` in the README, and clarified that
  `delete_old_docs` is a framework-level parameter (handled by Fess's
  crawling infrastructure, not this plugin) that must be set to `false`
  for a failed/aborted run to leave previously-indexed documents intact.

## Test plan

- [x] `mvn -o test` — 32/32 passing (was silently 0 before this PR)
- [x] New regression tests cover: unresolvable `commit_id` fail-fast,
      default-branch resolution (`main`), stale-lock-file cleanup,
      concurrent-lock fail-fast, source-change full-reindex fallback,
      credential/URL redaction, and RevWalk-closed-but-still-readable
      commit metadata
- [x] `mvn formatter:format && mvn license:format` — clean
