### PR TITLE
fix: preserve existing handler parameters verbatim on crawl-state write-back

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
@@ -398,12 +398,16 @@ public class GitDataStore extends AbstractDataStore {
      * @param toCommitId The new commit ID.
      */
     protected void updateDataConfig(final DataConfig dataConfig, final String sourceRef, final ObjectId toCommitId) {
-        final String paramStr = buildHandlerParameter(dataConfig.getHandlerParameterMap(), toCommitId.name(), sourceRef);
+        // Pass the RAW handlerParameter string, not getHandlerParameterMap() (which ParameterUtil.parse has
+        // already decrypted): buildHandlerParameter edits only prev_commit_id/prev_source_ref and preserves
+        // every other line verbatim, so encrypted values such as password={cipher}... keep their stored form
+        // instead of being rewritten decrypted on every crawl.
+        final String paramStr = buildHandlerParameter(dataConfig.getHandlerParameter(), toCommitId.name(), sourceRef);
         dataConfig.setHandlerParameter(paramStr);
         if (logger.isDebugEnabled()) {
-            // Do NOT log paramStr: it is the full handlerParameter string and carries the cleartext password
-            // and the raw uri userinfo. Log only non-sensitive identifiers; sourceRef is already redacted
-            // (it is the currentSourceRef built with redactUrl(uri) in storeData).
+            // Do NOT log paramStr: it is the full handlerParameter string and can still carry the raw uri
+            // userinfo (the uri parameter is not an encrypted key). Log only non-sensitive identifiers;
+            // sourceRef is already redacted (the currentSourceRef built with redactUrl(uri) in storeData).
             logger.debug("Updating data config {} to commit {} (source_ref={}).", dataConfig.getId(), toCommitId.name(), sourceRef);
         }
         ComponentUtil.getComponent(DataConfigBhv.class).update(dataConfig);
@@ -411,35 +415,52 @@ public class GitDataStore extends AbstractDataStore {
     }
 
     /**
-     * Builds the {@code handlerParameter} string with {@link #PREV_COMMIT_ID} and {@link #PREV_SOURCE_REF}
-     * applied using an "update in place if the key already exists, otherwise append" strategy so that
-     * existing keys keep their position and are never duplicated.
+     * Rebuilds the {@code handlerParameter} string with {@link #PREV_COMMIT_ID} and {@link #PREV_SOURCE_REF}
+     * applied using an "update in place if the key already exists, otherwise append" strategy so that existing
+     * keys keep their position and are never duplicated.
+     * <p>
+     * The <em>raw</em> stored string is edited line by line rather than being rebuilt from
+     * {@link DataConfig#getHandlerParameterMap()}: that map is already decrypted (by {@code ParameterUtil.parse}),
+     * so rebuilding from it would rewrite secret values such as {@code password={cipher}...} in their decrypted
+     * form. Every line other than the two keys updated here is preserved verbatim, keeping any encrypted values
+     * exactly as stored.
+     * </p>
      *
-     * @param handlerParameterMap The current handler parameter map.
+     * @param handlerParameter The current raw {@code handlerParameter} string (may be {@code null}).
      * @param prevCommitId The commit ID to persist as {@link #PREV_COMMIT_ID}.
      * @param prevSourceRef The source ref to persist as {@link #PREV_SOURCE_REF}.
      * @return The rebuilt {@code handlerParameter} string.
      */
-    protected String buildHandlerParameter(final Map<String, String> handlerParameterMap, final String prevCommitId,
-            final String prevSourceRef) {
-        final Map<String, String> newValues = new LinkedHashMap<>();
-        newValues.put(PREV_COMMIT_ID, prevCommitId);
-        newValues.put(PREV_SOURCE_REF, prevSourceRef);
+    protected String buildHandlerParameter(final String handlerParameter, final String prevCommitId, final String prevSourceRef) {
+        final Map<String, String> pending = new LinkedHashMap<>();
+        pending.put(PREV_COMMIT_ID, prevCommitId);
+        pending.put(PREV_SOURCE_REF, prevSourceRef);
 
         final StringBuilder buf = new StringBuilder();
-        handlerParameterMap.forEach((key, value) -> {
-            if (buf.length() > 0) {
-                buf.append('\n');
-            }
-            buf.append(key).append('=').append(newValues.getOrDefault(key, value));
-        });
-        newValues.forEach((key, value) -> {
-            if (!handlerParameterMap.containsKey(key)) {
+        if (handlerParameter != null) {
+            for (final String line : handlerParameter.split("[\r\n]")) {
+                if (StringUtil.isBlank(line)) {
+                    continue;
+                }
+                final int pos = line.indexOf('=');
+                final String key = (pos >= 0 ? line.substring(0, pos) : line).trim();
                 if (buf.length() > 0) {
                     buf.append('\n');
                 }
-                buf.append(key).append('=').append(value);
+                if (pending.containsKey(key)) {
+                    // Update PREV_COMMIT_ID / PREV_SOURCE_REF in place, keeping their original position.
+                    buf.append(key).append('=').append(pending.remove(key));
+                } else {
+                    // Preserve every other line verbatim so encrypted values (password={cipher}...) survive.
+                    buf.append(line);
+                }
             }
+        }
+        pending.forEach((key, value) -> {
+            if (buf.length() > 0) {
+                buf.append('\n');
+            }
+            buf.append(key).append('=').append(value);
         });
         return buf.toString();
     }

--- a/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
@@ -539,12 +539,9 @@ public class GitDataStoreTest extends UnitDsTestCase {
     @Test
     public void test_buildHandlerParameter_appendsWhenAbsent() {
         final GitDataStore dataStore = new GitDataStore();
-        final Map<String, String> handlerParameterMap = new LinkedHashMap<>();
-        handlerParameterMap.put("uri", "https://example.com/repo.git");
-        handlerParameterMap.put("base_url", "https://example.com/repo/blob/main/");
+        final String handlerParameter = "uri=https://example.com/repo.git\n" + "base_url=https://example.com/repo/blob/main/";
 
-        final String result =
-                dataStore.buildHandlerParameter(handlerParameterMap, "abc123", "https://example.com/repo.git#refs/heads/main");
+        final String result = dataStore.buildHandlerParameter(handlerParameter, "abc123", "https://example.com/repo.git#refs/heads/main");
 
         assertEquals("uri=https://example.com/repo.git\n" + "base_url=https://example.com/repo/blob/main/\n" + "prev_commit_id=abc123\n"
                 + "prev_source_ref=https://example.com/repo.git#refs/heads/main", result);
@@ -554,13 +551,11 @@ public class GitDataStoreTest extends UnitDsTestCase {
     @Test
     public void test_buildHandlerParameter_updatesInPlace() {
         final GitDataStore dataStore = new GitDataStore();
-        final Map<String, String> handlerParameterMap = new LinkedHashMap<>();
-        handlerParameterMap.put("uri", "https://example.com/repo.git");
-        handlerParameterMap.put("prev_commit_id", "OLD_COMMIT");
-        handlerParameterMap.put("prev_source_ref", "https://example.com/repo.git#refs/heads/OLD");
+        final String handlerParameter = "uri=https://example.com/repo.git\n" + "prev_commit_id=OLD_COMMIT\n"
+                + "prev_source_ref=https://example.com/repo.git#refs/heads/OLD";
 
         final String result =
-                dataStore.buildHandlerParameter(handlerParameterMap, "NEW_COMMIT", "https://example.com/repo.git#refs/heads/main");
+                dataStore.buildHandlerParameter(handlerParameter, "NEW_COMMIT", "https://example.com/repo.git#refs/heads/main");
 
         assertEquals("uri=https://example.com/repo.git\n" + "prev_commit_id=NEW_COMMIT\n"
                 + "prev_source_ref=https://example.com/repo.git#refs/heads/main", result);
@@ -573,12 +568,10 @@ public class GitDataStoreTest extends UnitDsTestCase {
     @Test
     public void test_buildHandlerParameter_mixedUpgrade() {
         final GitDataStore dataStore = new GitDataStore();
-        final Map<String, String> handlerParameterMap = new LinkedHashMap<>();
-        handlerParameterMap.put("uri", "https://example.com/repo.git");
-        handlerParameterMap.put("prev_commit_id", "OLD_COMMIT");
+        final String handlerParameter = "uri=https://example.com/repo.git\n" + "prev_commit_id=OLD_COMMIT";
 
         final String result =
-                dataStore.buildHandlerParameter(handlerParameterMap, "NEW_COMMIT", "https://example.com/repo.git#refs/heads/main");
+                dataStore.buildHandlerParameter(handlerParameter, "NEW_COMMIT", "https://example.com/repo.git#refs/heads/main");
 
         assertEquals("uri=https://example.com/repo.git\n" + "prev_commit_id=NEW_COMMIT\n"
                 + "prev_source_ref=https://example.com/repo.git#refs/heads/main", result);
@@ -593,10 +586,9 @@ public class GitDataStoreTest extends UnitDsTestCase {
     public void test_buildHandlerParameter_roundTripsThroughDataConfig() {
         final GitDataStore dataStore = new GitDataStore();
         final String sourceRef = "https://github.com/codelibs/fess.git#refs/heads/main";
-        final Map<String, String> handlerParameterMap = new LinkedHashMap<>();
-        handlerParameterMap.put("uri", "https://github.com/codelibs/fess.git");
+        final String handlerParameter = "uri=https://github.com/codelibs/fess.git";
 
-        final String result = dataStore.buildHandlerParameter(handlerParameterMap, "abc123", sourceRef);
+        final String result = dataStore.buildHandlerParameter(handlerParameter, "abc123", sourceRef);
 
         final DataConfig dataConfig = new DataConfig();
         dataConfig.setHandlerParameter(result);
@@ -605,6 +597,30 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertEquals(sourceRef, parsed.get("prev_source_ref"));
         // The value read back is exactly what the read side compares against.
         assertTrue(dataStore.isSameSource(parsed.get("prev_source_ref"), sourceRef));
+    }
+
+    // Write-back must edit the RAW handlerParameter string and preserve every non-target line verbatim -- in
+    // particular an encrypted value (password={cipher}...) must keep its stored form and never be rewritten in a
+    // decrypted state. Pre-fix, the write-back rebuilt the string from the already-decrypted
+    // getHandlerParameterMap(), which persisted the secret in cleartext to the config index on every crawl.
+    @Test
+    public void test_buildHandlerParameter_preservesEncryptedValueVerbatim() {
+        final GitDataStore dataStore = new GitDataStore();
+        final String handlerParameter =
+                "uri=https://example.com/repo.git\nusername=alice\npassword={cipher}ABCDEF0123456789\nprev_commit_id=OLD_COMMIT";
+
+        final String result =
+                dataStore.buildHandlerParameter(handlerParameter, "NEW_COMMIT", "https://example.com/repo.git#refs/heads/main");
+
+        // The encrypted secret and the other non-target lines are preserved exactly as stored.
+        assertTrue(result.lines().anyMatch(l -> l.equals("password={cipher}ABCDEF0123456789")));
+        assertTrue(result.lines().anyMatch(l -> l.equals("uri=https://example.com/repo.git")));
+        assertTrue(result.lines().anyMatch(l -> l.equals("username=alice")));
+        assertEquals(1L, result.lines().filter(l -> l.startsWith("password=")).count());
+        // prev_commit_id updated in place, prev_source_ref appended; no duplication.
+        assertEquals(1L, result.lines().filter(l -> l.startsWith("prev_commit_id=")).count());
+        assertTrue(result.lines().anyMatch(l -> l.equals("prev_commit_id=NEW_COMMIT")));
+        assertTrue(result.lines().anyMatch(l -> l.equals("prev_source_ref=https://example.com/repo.git#refs/heads/main")));
     }
 
     // Fix #2 (no regression): an explicitly configured commit_id/branch (non-HEAD) bypasses remote HEAD


### PR DESCRIPTION
## Summary

`GitDataStore.updateDataConfig()` persists the incremental-crawl state
(`prev_commit_id` / `prev_source_ref`) back to the `DataConfig` after each
successful crawl. It rebuilt the whole `handlerParameter` string from
`DataConfig.getHandlerParameterMap()`, which `ParameterUtil.parse()` has
already **decrypted**. Rebuilding from that map wrote every value back in its
decrypted representation — including parameters that are stored in encrypted
`{cipher}...` form — and the direct `DataConfigBhv.update()` call does not
re-encrypt (only `DataConfigService.store()` does). As a result the encrypted
form of those parameters was not preserved across crawls.

This changes `buildHandlerParameter()` to edit the **raw** `handlerParameter`
string line by line instead: it updates only `prev_commit_id` /
`prev_source_ref` (in place if present, otherwise appended) and preserves every
other line verbatim, so encrypted values keep their stored `{cipher}` form.
Behavior for all other parameters (ordering, no-duplication, round-trip) is
unchanged.

## Changes

- Rework `buildHandlerParameter()` to take the raw `handlerParameter` string
  instead of the parsed (decrypted) map, preserving non-target lines verbatim.
- `updateDataConfig()` now passes `getHandlerParameter()` (raw) instead of
  `getHandlerParameterMap()` (decrypted).
- Update the existing `buildHandlerParameter` unit tests to the new signature
  and add `test_buildHandlerParameter_preservesEncryptedValueVerbatim`.

## Notes

- Stacked on `fix/git-datastore-reliability` (PR #21), which reworked this same
  method; base is that branch and should be retargeted to `master` once #21
  merges.
- Existing configs whose parameters were previously rewritten in decrypted form
  are not rewritten by this change; re-saving the config through the admin UI
  restores the encrypted form.

## Test plan

- [x] `mvn -o test` — 44/44 passing
- [x] `mvn formatter:format && mvn license:format` — clean
