### PR TITLE
fix: avoid "Remote branch 'HEAD' not found" on persistent repository_path re-crawl

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
@@ -275,7 +275,7 @@ public class GitDataStore extends AbstractDataStore {
                     .setForceUpdate(true)
                     .setRemote(uri)
                     .setRefSpecs(new RefSpec(refSpec))
-                    .setInitialBranch(commitId)
+                    .setInitialBranch(resolveInitialBranch(commitId))
                     .setCredentialsProvider(credentialsProvider)
                     .call();
             if (logger.isDebugEnabled()) {
@@ -466,6 +466,32 @@ public class GitDataStore extends AbstractDataStore {
     }
 
     /**
+     * Determines the value to pass to JGit's
+     * {@link org.eclipse.jgit.api.FetchCommand#setInitialBranch(String)}.
+     * <p>
+     * JGit validates the initial branch as a concrete branch/tag name against the refs advertised by the
+     * remote ({@code FetchProcess.isInitialBranchMissing}). The default {@code commit_id} is the literal
+     * string {@code "HEAD"}, which is <em>not</em> a branch name: under protocol v2 the remote {@code HEAD}
+     * is advertised only when JGit itself requests it (an unborn local {@code HEAD}), so on a re-crawl of a
+     * persistent {@code repository_path} -- where the local {@code HEAD} is already born -- it is absent and
+     * the fetch fails with {@code "Remote branch 'HEAD' not found in upstream origin"}. Returning
+     * {@code null} for the default {@code HEAD}/blank case selects JGit's documented "use the branch pointed
+     * to by HEAD" behavior (equivalent to not calling {@code setInitialBranch} at all), while an explicitly
+     * configured branch/tag is still pinned unchanged so the common non-default case behaves exactly as
+     * before.
+     * </p>
+     *
+     * @param commitId The configured {@code commit_id}.
+     * @return The concrete branch/tag to pin, or {@code null} to use the remote's default branch.
+     */
+    protected String resolveInitialBranch(final String commitId) {
+        if (StringUtil.isBlank(commitId) || org.eclipse.jgit.lib.Constants.HEAD.equals(commitId)) {
+            return null;
+        }
+        return commitId;
+    }
+
+    /**
      * Resolves the commit reference to use for checkout and diffing.
      * <p>
      * When {@code commitId} defaults to {@link org.eclipse.jgit.lib.Constants#HEAD} (or is blank), the
@@ -484,6 +510,16 @@ public class GitDataStore extends AbstractDataStore {
      * would otherwise make {@link #isSameSource(String, String)} flip-flop across runs with no actual
      * branch/uri change, since the SHA moves as the branch advances.
      * </p>
+     * <p>
+     * On a re-crawl of a persistent {@code repository_path} the remote {@code HEAD} is often not advertised
+     * at all: under protocol v2, JGit only requests {@code HEAD} when the local {@code HEAD} is unborn, so
+     * once the first crawl has borne it the ref advertisement is filtered to the fetch refspec's prefixes
+     * (e.g. {@code refs/heads/}) and carries no {@code HEAD}. In that case the local {@code HEAD}'s symref
+     * target -- established by the first crawl -- is used via {@link #resolveLocalHeadTarget(Repository,
+     * String)} instead of falling back to the literal {@code "HEAD"} string, which would otherwise make
+     * {@code prev_source_ref} flip-flop between {@code refs/heads/main} and {@code HEAD} and force a spurious
+     * full reindex.
+     * </p>
      *
      * @param repository The Git repository.
      * @param fetchResult The result of the fetch operation.
@@ -498,7 +534,7 @@ public class GitDataStore extends AbstractDataStore {
         }
         final Ref headRef = fetchResult.getAdvertisedRef(org.eclipse.jgit.lib.Constants.HEAD);
         if (headRef == null) {
-            return commitId;
+            return resolveLocalHeadTarget(repository, commitId);
         }
         if (headRef.isSymbolic()) {
             final String targetName = headRef.getTarget().getName();
@@ -511,6 +547,28 @@ public class GitDataStore extends AbstractDataStore {
             return matchedBranch;
         }
         return headRef.getObjectId().name();
+    }
+
+    /**
+     * Resolves the local {@code HEAD}'s symbolic target (e.g. {@code refs/heads/main}). Used as a fallback by
+     * {@link #resolveDefaultBranch(Repository, FetchResult, String)} when the remote {@code HEAD} is not
+     * advertised on a fetch (a protocol-v2 re-crawl of a persistent {@code repository_path} whose local
+     * {@code HEAD} is already born). Returning the symref target keeps the resolved ref -- and therefore
+     * {@code prev_source_ref} -- identical to what the first crawl recorded, so incremental crawling keeps
+     * working across runs. When the local {@code HEAD} is missing or detached (no symref, e.g.
+     * detached/anonymous history), {@code commitId} is returned unchanged, preserving the prior behavior.
+     *
+     * @param repository The Git repository.
+     * @param commitId The configured commit ID, returned unchanged when the local {@code HEAD} is not symbolic.
+     * @return The local {@code HEAD}'s symref target, or {@code commitId} if it is missing or detached.
+     * @throws IOException If reading the local {@code HEAD} fails.
+     */
+    protected String resolveLocalHeadTarget(final Repository repository, final String commitId) throws IOException {
+        final Ref localHead = repository.exactRef(org.eclipse.jgit.lib.Constants.HEAD);
+        if (localHead != null && localHead.isSymbolic()) {
+            return localHead.getTarget().getName();
+        }
+        return commitId;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/git/GitDataStore.java
@@ -271,21 +271,26 @@ public class GitDataStore extends AbstractDataStore {
         final Repository repository = (Repository) configMap.get(REPOSITORY);
         try (final Git git = new Git(repository)) {
             configMap.put(GIT, git);
+            final RefSpec fetchRefSpec = new RefSpec(refSpec);
             final FetchResult fetchResult = git.fetch()
                     .setForceUpdate(true)
                     .setRemote(uri)
-                    .setRefSpecs(new RefSpec(refSpec))
+                    .setRefSpecs(fetchRefSpec)
                     .setInitialBranch(resolveInitialBranch(commitId))
                     .setCredentialsProvider(credentialsProvider)
                     .call();
             if (logger.isDebugEnabled()) {
                 logger.debug("Fetch Result: {}", fetchResult.getMessages());
             }
-            final String resolvedCommitId = resolveDefaultBranch(repository, fetchResult, commitId);
+            final String resolvedCommitId = resolveDefaultBranch(repository, fetchResult, fetchRefSpec, commitId);
             if (!hasCommitLogs(configMap)) {
                 final Ref ref = git.checkout().setName(resolvedCommitId).call();
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Checked out {}", ref.getName());
+                    // CheckoutCommand.call() returns null when the checkout detaches HEAD: it looks the name up
+                    // with findRef() and keeps only a refs/heads/* match, so a commit SHA (an explicit commit_id,
+                    // or resolveDefaultBranch()'s bare-SHA result for anonymous history) yields null while HEAD is
+                    // force-updated to the commit. Log the resolved ref rather than dereferencing that null.
+                    logger.debug("Checked out {}", ref != null ? ref.getName() : resolvedCommitId);
                 }
             }
             final String currentSourceRef = redactUrl(uri) + "#" + resolvedCommitId;
@@ -480,12 +485,27 @@ public class GitDataStore extends AbstractDataStore {
      * configured branch/tag is still pinned unchanged so the common non-default case behaves exactly as
      * before.
      * </p>
+     * <p>
+     * A {@code commit_id} that is a full 40-character object id is mapped to {@code null} for the same
+     * reason: a SHA is not a branch or tag name either, so JGit's validation rejects it and the fetch fails
+     * with {@code "Remote branch '<sha>' not found in upstream origin"} on <em>every</em> run. Skipping the
+     * validation is safe because the refspec fetches the branches regardless, and
+     * {@link #resolveToCommitId(Repository, String, String)} then resolves the SHA against the local
+     * repository (failing with a clear message if it is not reachable from any fetched ref).
+     * </p>
+     * <p>
+     * Known limitation: an <em>abbreviated</em> SHA (e.g. {@code 6973e6a}) is not recognized here --
+     * {@link ObjectId#isId(String)} matches only the full 40-character form -- and is therefore still passed
+     * through and still rejected by JGit's validation. It is indistinguishable from a legitimate branch name
+     * at this point (a branch may literally be named {@code 6973e6a}), so it is left to the existing
+     * branch/tag handling rather than guessed at.
+     * </p>
      *
      * @param commitId The configured {@code commit_id}.
      * @return The concrete branch/tag to pin, or {@code null} to use the remote's default branch.
      */
     protected String resolveInitialBranch(final String commitId) {
-        if (StringUtil.isBlank(commitId) || org.eclipse.jgit.lib.Constants.HEAD.equals(commitId)) {
+        if (StringUtil.isBlank(commitId) || org.eclipse.jgit.lib.Constants.HEAD.equals(commitId) || ObjectId.isId(commitId)) {
             return null;
         }
         return commitId;
@@ -515,26 +535,28 @@ public class GitDataStore extends AbstractDataStore {
      * at all: under protocol v2, JGit only requests {@code HEAD} when the local {@code HEAD} is unborn, so
      * once the first crawl has borne it the ref advertisement is filtered to the fetch refspec's prefixes
      * (e.g. {@code refs/heads/}) and carries no {@code HEAD}. In that case the local {@code HEAD}'s symref
-     * target -- established by the first crawl -- is used via {@link #resolveLocalHeadTarget(Repository,
-     * String)} instead of falling back to the literal {@code "HEAD"} string, which would otherwise make
-     * {@code prev_source_ref} flip-flop between {@code refs/heads/main} and {@code HEAD} and force a spurious
-     * full reindex.
+     * target -- established by the first crawl -- is used via
+     * {@link #resolveLocalHeadTarget(Repository, FetchResult, RefSpec, String)} instead of falling back to the
+     * literal {@code "HEAD"} string, which would otherwise make {@code prev_source_ref} flip-flop between
+     * {@code refs/heads/main} and {@code HEAD} and force a spurious full reindex.
      * </p>
      *
      * @param repository The Git repository.
      * @param fetchResult The result of the fetch operation.
+     * @param refSpec The refspec used for the fetch, used to tell a branch deleted upstream apart from one the
+     *            refspec simply does not cover; may be {@code null} to skip that check.
      * @param commitId The configured commit ID.
      * @return The resolved commit reference to use for checkout and resolution.
      * @throws IOException If updating the local {@code HEAD} fails.
      */
-    protected String resolveDefaultBranch(final Repository repository, final FetchResult fetchResult, final String commitId)
-            throws IOException {
+    protected String resolveDefaultBranch(final Repository repository, final FetchResult fetchResult, final RefSpec refSpec,
+            final String commitId) throws IOException {
         if (StringUtil.isNotBlank(commitId) && !org.eclipse.jgit.lib.Constants.HEAD.equals(commitId)) {
             return commitId;
         }
         final Ref headRef = fetchResult.getAdvertisedRef(org.eclipse.jgit.lib.Constants.HEAD);
         if (headRef == null) {
-            return resolveLocalHeadTarget(repository, commitId);
+            return resolveLocalHeadTarget(repository, fetchResult, refSpec, commitId);
         }
         if (headRef.isSymbolic()) {
             final String targetName = headRef.getTarget().getName();
@@ -551,24 +573,50 @@ public class GitDataStore extends AbstractDataStore {
 
     /**
      * Resolves the local {@code HEAD}'s symbolic target (e.g. {@code refs/heads/main}). Used as a fallback by
-     * {@link #resolveDefaultBranch(Repository, FetchResult, String)} when the remote {@code HEAD} is not
-     * advertised on a fetch (a protocol-v2 re-crawl of a persistent {@code repository_path} whose local
+     * {@link #resolveDefaultBranch(Repository, FetchResult, RefSpec, String)} when the remote {@code HEAD} is
+     * not advertised on a fetch (a protocol-v2 re-crawl of a persistent {@code repository_path} whose local
      * {@code HEAD} is already born). Returning the symref target keeps the resolved ref -- and therefore
      * {@code prev_source_ref} -- identical to what the first crawl recorded, so incremental crawling keeps
      * working across runs. When the local {@code HEAD} is missing or detached (no symref, e.g.
      * detached/anonymous history), {@code commitId} is returned unchanged, preserving the prior behavior.
+     * <p>
+     * The local {@code HEAD} is a cached copy of what the remote's default branch was on the <em>first</em>
+     * crawl, so it is verified against the current advertisement before being trusted. If the remote's default
+     * branch is renamed or deleted (e.g. {@code master} -> {@code main}), the stale local branch is not pruned
+     * by the fetch (no {@code setRemoveDeletedRefs(true)}, and it is no longer advertised to be updated), so it
+     * still resolves -- to its last-known commit. Silently trusting it would diff that unchanged commit against
+     * itself, index nothing, and report success, which (unless {@code delete_old_docs=false}) additionally lets
+     * Fess prune every previously-indexed document of this config. Failing with an actionable message is
+     * strictly more diagnosable than that.
+     * </p>
+     * <p>
+     * The check is gated on {@code refSpec} actually covering the target: with a narrowed {@code ref_specs}
+     * (e.g. {@code +refs/heads/foo:refs/heads/foo}) the advertisement is filtered to that prefix, so a local
+     * {@code HEAD} pointing outside it is legitimately absent and must not be mistaken for one deleted upstream.
+     * </p>
      *
      * @param repository The Git repository.
+     * @param fetchResult The result of the fetch operation, whose advertised refs the target is verified
+     *            against; may be {@code null} to skip that verification.
+     * @param refSpec The refspec used for the fetch; the verification is skipped unless it covers the target.
      * @param commitId The configured commit ID, returned unchanged when the local {@code HEAD} is not symbolic.
      * @return The local {@code HEAD}'s symref target, or {@code commitId} if it is missing or detached.
      * @throws IOException If reading the local {@code HEAD} fails.
      */
-    protected String resolveLocalHeadTarget(final Repository repository, final String commitId) throws IOException {
+    protected String resolveLocalHeadTarget(final Repository repository, final FetchResult fetchResult, final RefSpec refSpec,
+            final String commitId) throws IOException {
         final Ref localHead = repository.exactRef(org.eclipse.jgit.lib.Constants.HEAD);
-        if (localHead != null && localHead.isSymbolic()) {
-            return localHead.getTarget().getName();
+        if (localHead == null || !localHead.isSymbolic()) {
+            return commitId;
         }
-        return commitId;
+        final String targetName = localHead.getTarget().getName();
+        if (fetchResult != null && refSpec != null && refSpec.matchSource(targetName) && fetchResult.getAdvertisedRef(targetName) == null) {
+            throw new DataStoreException("The branch '" + targetName
+                    + "' that a previous crawl resolved as this repository's default branch is no longer advertised by the remote; "
+                    + "it was most likely renamed or deleted upstream. Set commit_id to the new branch name, or remove the "
+                    + "repository_path directory so the remote's current default branch is picked up again.");
+        }
+        return targetName;
     }
 
     /**
@@ -586,7 +634,7 @@ public class GitDataStore extends AbstractDataStore {
 
     /**
      * Scans the given advertised refs for one under {@code refs/heads/} whose object id matches {@code headId}.
-     * Used by {@link #resolveDefaultBranch(Repository, FetchResult, String)} to identify a branch name by
+     * Used by {@link #resolveDefaultBranch(Repository, FetchResult, RefSpec, String)} to identify a branch name by
      * content when the advertised {@code HEAD} is not symbolic. This is similar in intent to JGit's own
      * {@code CloneCommand#findBranchToCheckout(FetchResult)}, but does NOT replicate its tiebreak: when several
      * advertised branches share {@code HEAD}'s object id, JGit specially prefers {@code refs/heads/master},

--- a/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Constructor;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
@@ -62,6 +63,7 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.transport.FetchResult;
 
 public class GitDataStoreTest extends UnitDsTestCase {
 
@@ -633,6 +635,193 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertEquals("v1.2.3", dataStore.resolveDefaultBranch(null, null, "v1.2.3"));
         assertEquals("0123456789abcdef0123456789abcdef01234567",
                 dataStore.resolveDefaultBranch(null, null, "0123456789abcdef0123456789abcdef01234567"));
+    }
+
+    // Bug fix: the default commit_id is the literal string "HEAD", which JGit's FetchProcess treats as a
+    // concrete branch name and validates against the advertised refs. Under protocol v2 the remote HEAD is
+    // only advertised when JGit requests it (an unborn local HEAD), so a re-crawl of a persistent
+    // repository_path (born local HEAD) fails with "Remote branch 'HEAD' not found in upstream origin".
+    // resolveInitialBranch() maps the default HEAD/blank case to null (JGit's "use the default branch"
+    // sentinel) while pinning an explicitly configured branch/tag unchanged.
+    @Test
+    public void test_resolveInitialBranch() {
+        final GitDataStore dataStore = new GitDataStore();
+        assertNull(dataStore.resolveInitialBranch("HEAD"));
+        assertNull(dataStore.resolveInitialBranch(null));
+        assertNull(dataStore.resolveInitialBranch(""));
+        assertNull(dataStore.resolveInitialBranch("   "));
+        assertEquals("main", dataStore.resolveInitialBranch("main"));
+        assertEquals("refs/heads/dev", dataStore.resolveInitialBranch("refs/heads/dev"));
+        assertEquals("v1.2.3", dataStore.resolveInitialBranch("v1.2.3"));
+        // A non-default value is passed through verbatim (no special-casing). A raw SHA is returned unchanged
+        // for the same reason; whether such a commit_id fetches successfully is a separate, pre-existing
+        // concern (JGit's setInitialBranch validates against advertised ref names) and is unchanged here.
+        assertEquals("0123456789abcdef0123456789abcdef01234567",
+                dataStore.resolveInitialBranch("0123456789abcdef0123456789abcdef01234567"));
+    }
+
+    // Bug fix (fallback): on a protocol-v2 re-crawl of a persistent repository_path the remote HEAD is not
+    // advertised, so resolveDefaultBranch() falls back to the local HEAD's symref target (established by the
+    // first crawl) instead of the literal "HEAD" -- keeping the resolved ref, and thus prev_source_ref,
+    // stable across runs. A symbolic local HEAD resolves to its target branch.
+    @Test
+    public void test_resolveLocalHeadTarget_symbolicHead() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File repoDir = createLocalRepo("main", files);
+        final GitDataStore dataStore = new GitDataStore();
+        try (Git git = Git.open(repoDir)) {
+            final Repository repo = git.getRepository();
+            // A freshly-created repo's HEAD is the symbolic ref "ref: refs/heads/main".
+            assertEquals("refs/heads/main", dataStore.resolveLocalHeadTarget(repo, "HEAD"));
+        }
+    }
+
+    // Bug fix (fallback): when the local HEAD is detached (no symref, e.g. detached/anonymous history), there
+    // is no branch name to recover, so resolveLocalHeadTarget() returns the configured commitId unchanged,
+    // preserving the prior behavior.
+    @Test
+    public void test_resolveLocalHeadTarget_detachedHeadReturnsCommitId() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File repoDir = createLocalRepo("main", files);
+        final GitDataStore dataStore = new GitDataStore();
+        try (Git git = Git.open(repoDir)) {
+            final Repository repo = git.getRepository();
+            // Checking out a commit id (not a branch) detaches HEAD.
+            final ObjectId head = repo.resolve("HEAD");
+            git.checkout().setName(head.name()).call();
+            assertFalse(repo.exactRef("HEAD").isSymbolic());
+            assertEquals("HEAD", dataStore.resolveLocalHeadTarget(repo, "HEAD"));
+        }
+    }
+
+    // Bug fix (fallback wiring): directly exercises the headRef == null branch of resolveDefaultBranch, which
+    // the local file:// transport (always advertises HEAD) cannot reach through storeData. JGit's FetchResult
+    // has no public constructor; an empty one models a protocol-v2 re-crawl whose advertised refs carry no
+    // HEAD. resolveDefaultBranch must then return the local HEAD's symref target ("refs/heads/main"), NOT the
+    // literal "HEAD" the pre-fix code returned -- so this fails if the fallback is reverted to `return commitId`.
+    @Test
+    public void test_resolveDefaultBranch_fallsBackToLocalHeadWhenHeadNotAdvertised() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File repoDir = createLocalRepo("main", files);
+        final GitDataStore dataStore = new GitDataStore();
+        try (Git git = Git.open(repoDir)) {
+            final Repository repo = git.getRepository();
+            final Constructor<FetchResult> ctor = FetchResult.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            final FetchResult emptyFetchResult = ctor.newInstance();
+            assertNull(emptyFetchResult.getAdvertisedRef("HEAD"));
+            assertEquals("refs/heads/main", dataStore.resolveDefaultBranch(repo, emptyFetchResult, "HEAD"));
+        }
+    }
+
+    // Bug fix (end-to-end): a re-crawl against a persistent repository_path (where the local HEAD is already
+    // born) must succeed and stay incremental. This is the scenario that triggered the reported
+    // "Remote branch 'HEAD' not found in upstream origin" crash. (The local file:// transport used here
+    // always advertises HEAD, so this test guards the whole persistent re-crawl flow -- including that the
+    // resolved ref / prev_source_ref stays stable so the second run is incremental; the v2-specific
+    // mechanics a local transport cannot reproduce are covered by test_resolveInitialBranch() and
+    // test_resolveLocalHeadTarget_*.)
+    @Test
+    public void test_storeData_persistentRepositoryRecrawl() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createLocalRepo("main", files);
+
+        final File persistent = Files.createTempDirectory("fess-ds-git-persist-").toFile();
+        tempDirs.add(persistent);
+
+        // First crawl: fresh persistent repository_path (unborn local HEAD). Capture what gets persisted so
+        // the second run can be driven exactly as Fess's write-back would drive it.
+        final DataStoreParams firstParams = new DataStoreParams();
+        firstParams.put("uri", remote.getAbsolutePath());
+        firstParams.put("repository_path", persistent.getAbsolutePath());
+        final List<String> firstUrls = new ArrayList<>();
+        final AtomicReference<String> sourceRef = new AtomicReference<>();
+        final AtomicReference<ObjectId> commitId = new AtomicReference<>();
+        final GitDataStore firstRun = new GitDataStore() {
+            @Override
+            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
+                return new MockUrlFilter();
+            }
+
+            @Override
+            protected void processFile(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
+                    final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final Map<String, Object> configMap) {
+                firstUrls.add(((DiffEntry) configMap.get(DIFF_ENTRY)).getNewPath());
+            }
+
+            @Override
+            protected void updateDataConfig(final DataConfig dc, final String ref, final ObjectId toCommitId) {
+                sourceRef.set(ref);
+                commitId.set(toCommitId);
+            }
+        };
+        firstRun.storeData(new DataConfig(), null, firstParams, null, null);
+        assertTrue(firstUrls.contains("a.txt"));
+        assertNotNull(sourceRef.get());
+        assertNotNull(commitId.get());
+
+        // A new commit lands upstream between crawls.
+        try (Git git = Git.open(remote)) {
+            final Map<String, String> second = new LinkedHashMap<>();
+            second.put("b.txt", "b");
+            addAndCommit(git, remote, second, "c2");
+        }
+
+        // Second crawl: the persistent repository_path now has a born local HEAD -- the exact state that made
+        // setInitialBranch("HEAD") throw. It must succeed and, because prev_source_ref matches, be incremental.
+        final DataStoreParams secondParams = new DataStoreParams();
+        secondParams.put("uri", remote.getAbsolutePath());
+        secondParams.put("repository_path", persistent.getAbsolutePath());
+        secondParams.put("prev_commit_id", commitId.get().name());
+        secondParams.put("prev_source_ref", sourceRef.get());
+        final List<String> secondUrls = new ArrayList<>();
+        newCollectingDataStore(secondUrls).storeData(null, null, secondParams, null, null);
+
+        assertTrue(secondUrls.contains("b.txt"));
+        assertFalse(secondUrls.contains("a.txt"));
+    }
+
+    // Bug fix (initial-branch wiring): proves storeData() passes resolveInitialBranch()'s result -- not the raw
+    // commit_id -- to FetchCommand.setInitialBranch(). resolveInitialBranch is overridden to return a branch
+    // that does not exist on the remote, so JGit's isInitialBranchMissing check fails the fetch with that exact
+    // name. If storeData instead passed the literal commit_id "HEAD" (the pre-fix behavior), the local
+    // transport would advertise HEAD and the crawl would succeed -- so this fails if the wiring is reverted.
+    @Test
+    public void test_storeData_usesResolvedInitialBranchForFetch() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createLocalRepo("main", files);
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remote.getAbsolutePath());
+        final GitDataStore dataStore = new GitDataStore() {
+            @Override
+            protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
+                return new MockUrlFilter();
+            }
+
+            @Override
+            protected String resolveInitialBranch(final String commitId) {
+                return "does-not-exist-branch";
+            }
+        };
+        try {
+            dataStore.storeData(null, null, params, null, null);
+            fail("Expected DataStoreException");
+        } catch (final DataStoreException e) {
+            boolean found = false;
+            for (Throwable t = e; t != null; t = t.getCause()) {
+                if (t.getMessage() != null && t.getMessage().contains("does-not-exist-branch")) {
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue("Expected the fetch to fail on the missing initial branch, but got: " + e, found);
+        }
     }
 
     // Fix #11: for a brand-new (not-yet-existing) repository_path, the advisory lock must be acquired BEFORE

--- a/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/git/GitDataStoreTest.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Constructor;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
@@ -64,6 +63,7 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.FetchResult;
+import org.eclipse.jgit.transport.RefSpec;
 
 public class GitDataStoreTest extends UnitDsTestCase {
 
@@ -103,6 +103,29 @@ public class GitDataStoreTest extends UnitDsTestCase {
         tempDirs.add(dir);
         try (Git git = Git.init().setInitialBranch(initialBranch).setDirectory(dir).call()) {
             addAndCommit(git, dir, files, "initial commit");
+        }
+        return dir;
+    }
+
+    /**
+     * Creates a local scratch Git repository that advertises no {@code HEAD} ref, committing {@code files} on
+     * {@code realBranch}.
+     * <p>
+     * Pointing {@code HEAD} at a branch that does not exist makes JGit drop it from the ref advertisement: a
+     * broken symbolic ref is removed by {@code RefDirectory} ("A broken symbolic reference, we have to drop it
+     * from the collections the client is about to receive") and {@code RefAdvertiser} skips any ref with a
+     * {@code null} object id. This is the only way to produce the "{@code HEAD} is not advertised" condition
+     * over the local {@code file://} transport, which advertises {@code HEAD} for an ordinary remote -- and
+     * that condition is exactly what a protocol-v2 re-crawl hits once the local {@code HEAD} is born, so it
+     * reproduces the reported failure's precondition without needing an HTTP/v2 test server.
+     * </p>
+     */
+    private File createRepoWithUnadvertisedHead(final String realBranch, final Map<String, String> files) throws Exception {
+        final File dir = Files.createTempDirectory("fess-ds-git-nohead-").toFile();
+        tempDirs.add(dir);
+        try (Git git = Git.init().setInitialBranch(realBranch).setDirectory(dir).call()) {
+            addAndCommit(git, dir, files, "initial commit");
+            git.getRepository().updateRef(org.eclipse.jgit.lib.Constants.HEAD).link("refs/heads/nonexistent-branch");
         }
         return dir;
     }
@@ -631,10 +654,10 @@ public class GitDataStoreTest extends UnitDsTestCase {
     public void test_resolveDefaultBranch_explicitCommitIdBypass() throws Exception {
         final GitDataStore dataStore = new GitDataStore();
         // The early return fires before fetchResult/repository are touched, so null args are safe here.
-        assertEquals("refs/heads/dev", dataStore.resolveDefaultBranch(null, null, "refs/heads/dev"));
-        assertEquals("v1.2.3", dataStore.resolveDefaultBranch(null, null, "v1.2.3"));
+        assertEquals("refs/heads/dev", dataStore.resolveDefaultBranch(null, null, null, "refs/heads/dev"));
+        assertEquals("v1.2.3", dataStore.resolveDefaultBranch(null, null, null, "v1.2.3"));
         assertEquals("0123456789abcdef0123456789abcdef01234567",
-                dataStore.resolveDefaultBranch(null, null, "0123456789abcdef0123456789abcdef01234567"));
+                dataStore.resolveDefaultBranch(null, null, null, "0123456789abcdef0123456789abcdef01234567"));
     }
 
     // Bug fix: the default commit_id is the literal string "HEAD", which JGit's FetchProcess treats as a
@@ -653,11 +676,14 @@ public class GitDataStoreTest extends UnitDsTestCase {
         assertEquals("main", dataStore.resolveInitialBranch("main"));
         assertEquals("refs/heads/dev", dataStore.resolveInitialBranch("refs/heads/dev"));
         assertEquals("v1.2.3", dataStore.resolveInitialBranch("v1.2.3"));
-        // A non-default value is passed through verbatim (no special-casing). A raw SHA is returned unchanged
-        // for the same reason; whether such a commit_id fetches successfully is a separate, pre-existing
-        // concern (JGit's setInitialBranch validates against advertised ref names) and is unchanged here.
-        assertEquals("0123456789abcdef0123456789abcdef01234567",
-                dataStore.resolveInitialBranch("0123456789abcdef0123456789abcdef01234567"));
+        // A full 40-char SHA is not a branch/tag name either, so JGit's validation would reject it on every
+        // run ("Remote branch '<sha>' not found in upstream origin"). It maps to null for the same reason
+        // HEAD does; resolveToCommitId() still resolves it locally afterwards.
+        assertNull(dataStore.resolveInitialBranch("0123456789abcdef0123456789abcdef01234567"));
+        assertNull(dataStore.resolveInitialBranch("0123456789ABCDEF0123456789ABCDEF01234567"));
+        // Documented limitation: an abbreviated SHA is indistinguishable from a branch name here
+        // (ObjectId.isId matches only the full form), so it is passed through like any other name.
+        assertEquals("0123456", dataStore.resolveInitialBranch("0123456"));
     }
 
     // Bug fix (fallback): on a protocol-v2 re-crawl of a persistent repository_path the remote HEAD is not
@@ -673,7 +699,9 @@ public class GitDataStoreTest extends UnitDsTestCase {
         try (Git git = Git.open(repoDir)) {
             final Repository repo = git.getRepository();
             // A freshly-created repo's HEAD is the symbolic ref "ref: refs/heads/main".
-            assertEquals("refs/heads/main", dataStore.resolveLocalHeadTarget(repo, "HEAD"));
+            // No fetchResult/refSpec: the "still advertised?" verification is skipped and the symref target
+            // is returned as-is.
+            assertEquals("refs/heads/main", dataStore.resolveLocalHeadTarget(repo, null, null, "HEAD"));
         }
     }
 
@@ -692,38 +720,178 @@ public class GitDataStoreTest extends UnitDsTestCase {
             final ObjectId head = repo.resolve("HEAD");
             git.checkout().setName(head.name()).call();
             assertFalse(repo.exactRef("HEAD").isSymbolic());
-            assertEquals("HEAD", dataStore.resolveLocalHeadTarget(repo, "HEAD"));
+            assertEquals("HEAD", dataStore.resolveLocalHeadTarget(repo, null, null, "HEAD"));
         }
     }
 
-    // Bug fix (fallback wiring): directly exercises the headRef == null branch of resolveDefaultBranch, which
-    // the local file:// transport (always advertises HEAD) cannot reach through storeData. JGit's FetchResult
-    // has no public constructor; an empty one models a protocol-v2 re-crawl whose advertised refs carry no
-    // HEAD. resolveDefaultBranch must then return the local HEAD's symref target ("refs/heads/main"), NOT the
-    // literal "HEAD" the pre-fix code returned -- so this fails if the fallback is reverted to `return commitId`.
+    // Bug fix (end-to-end): a commit_id given as a full SHA must actually crawl. JGit validates the initial
+    // branch as a branch/tag name, so passing a SHA through failed the fetch with "Remote branch '<sha>' not
+    // found in upstream origin" on every run -- fresh clone included. resolveInitialBranch() now maps a full
+    // SHA to null (the refspec fetches the branches regardless), and the SHA is resolved locally afterwards.
+    @Test
+    public void test_storeData_withRawShaCommitId() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createLocalRepo("main", files);
+        final String firstSha;
+        try (Git git = Git.open(remote)) {
+            firstSha = git.getRepository().resolve("refs/heads/main").name();
+            // A later commit the pinned SHA must NOT pick up, proving the SHA is what was crawled.
+            final Map<String, String> second = new LinkedHashMap<>();
+            second.put("b.txt", "b");
+            addAndCommit(git, remote, second, "c2");
+        }
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remote.getAbsolutePath());
+        params.put("commit_id", firstSha);
+
+        final List<String> urlList = new ArrayList<>();
+        newCollectingDataStore(urlList).storeData(null, null, params, null, null);
+
+        assertTrue(urlList.contains("a.txt"));
+        assertFalse(urlList.contains("b.txt"));
+    }
+
+    // Bug fix (fallback wiring): exercises the headRef == null branch of resolveDefaultBranch using a REAL
+    // FetchResult from a real fetch against a remote that genuinely advertises no HEAD (see
+    // createRepoWithUnadvertisedHead) -- the same "HEAD absent from the advertisement" shape a protocol-v2
+    // re-crawl produces. resolveDefaultBranch must then return the local HEAD's symref target
+    // ("refs/heads/foo"), NOT the literal "HEAD" the pre-fix code returned -- so this fails if the fallback is
+    // reverted to `return commitId`.
     @Test
     public void test_resolveDefaultBranch_fallsBackToLocalHeadWhenHeadNotAdvertised() throws Exception {
         final Map<String, String> files = new LinkedHashMap<>();
         files.put("a.txt", "a");
-        final File repoDir = createLocalRepo("main", files);
-        final GitDataStore dataStore = new GitDataStore();
-        try (Git git = Git.open(repoDir)) {
-            final Repository repo = git.getRepository();
-            final Constructor<FetchResult> ctor = FetchResult.class.getDeclaredConstructor();
-            ctor.setAccessible(true);
-            final FetchResult emptyFetchResult = ctor.newInstance();
-            assertNull(emptyFetchResult.getAdvertisedRef("HEAD"));
-            assertEquals("refs/heads/main", dataStore.resolveDefaultBranch(repo, emptyFetchResult, "HEAD"));
+        final File remote = createRepoWithUnadvertisedHead("foo", files);
+
+        final File localDir = Files.createTempDirectory("fess-ds-git-local-").toFile();
+        tempDirs.add(localDir);
+        final Repository local = FileRepositoryBuilder.create(new File(localDir, ".git"));
+        local.create();
+        try (Git git = new Git(local)) {
+            final FetchResult fetchResult = git.fetch()
+                    .setForceUpdate(true)
+                    .setRemote(remote.getAbsolutePath())
+                    .setRefSpecs(new RefSpec("+refs/heads/*:refs/heads/*"))
+                    .call();
+            // Not a synthetic stand-in: the remote really advertised no HEAD.
+            assertNull(fetchResult.getAdvertisedRef("HEAD"));
+            // The symref a previous crawl's linkLocalHead() would have established.
+            local.updateRef(org.eclipse.jgit.lib.Constants.HEAD).link("refs/heads/foo");
+
+            final GitDataStore dataStore = new GitDataStore();
+            assertEquals("refs/heads/foo",
+                    dataStore.resolveDefaultBranch(local, fetchResult, new RefSpec("+refs/heads/*:refs/heads/*"), "HEAD"));
+        } finally {
+            local.close();
         }
+    }
+
+    // The local HEAD is only a cache of what the remote's default branch was on the FIRST crawl. If that branch
+    // is renamed/deleted upstream it is not pruned locally (the fetch sets no removeDeletedRefs) and still
+    // resolves to its last-known commit, so trusting it would diff that commit against itself: zero documents
+    // indexed, crawl reported successful. Verify the stale target is rejected with an actionable error instead.
+    @Test
+    public void test_resolveLocalHeadTarget_failsWhenTargetNoLongerAdvertised() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        // Remote advertises refs/heads/main (and no HEAD); the local HEAD still points at the old refs/heads/master.
+        final File remote = createRepoWithUnadvertisedHead("main", files);
+
+        final File localDir = Files.createTempDirectory("fess-ds-git-local-").toFile();
+        tempDirs.add(localDir);
+        final Repository local = FileRepositoryBuilder.create(new File(localDir, ".git"));
+        local.create();
+        try (Git git = new Git(local)) {
+            final FetchResult fetchResult = git.fetch()
+                    .setForceUpdate(true)
+                    .setRemote(remote.getAbsolutePath())
+                    .setRefSpecs(new RefSpec("+refs/heads/*:refs/heads/*"))
+                    .call();
+            local.updateRef(org.eclipse.jgit.lib.Constants.HEAD).link("refs/heads/master");
+
+            final GitDataStore dataStore = new GitDataStore();
+            try {
+                dataStore.resolveLocalHeadTarget(local, fetchResult, new RefSpec("+refs/heads/*:refs/heads/*"), "HEAD");
+                fail("Expected DataStoreException for a default branch that vanished upstream");
+            } catch (final DataStoreException e) {
+                assertTrue(e.getMessage().contains("refs/heads/master"));
+            }
+        } finally {
+            local.close();
+        }
+    }
+
+    // The "still advertised?" check must not fire when the refspec simply does not cover the local HEAD: with a
+    // narrowed ref_specs the advertisement is filtered to that prefix, so a HEAD pointing outside it is
+    // legitimately absent and must not be mistaken for a branch deleted upstream.
+    @Test
+    public void test_resolveLocalHeadTarget_narrowedRefSpecDoesNotFalselyFail() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createRepoWithUnadvertisedHead("main", files);
+
+        final File localDir = Files.createTempDirectory("fess-ds-git-local-").toFile();
+        tempDirs.add(localDir);
+        final Repository local = FileRepositoryBuilder.create(new File(localDir, ".git"));
+        local.create();
+        try (Git git = new Git(local)) {
+            final FetchResult fetchResult = git.fetch()
+                    .setForceUpdate(true)
+                    .setRemote(remote.getAbsolutePath())
+                    .setRefSpecs(new RefSpec("+refs/heads/*:refs/heads/*"))
+                    .call();
+            local.updateRef(org.eclipse.jgit.lib.Constants.HEAD).link("refs/heads/other");
+
+            // refs/heads/other is outside this refspec, so its absence proves nothing and must be tolerated.
+            final GitDataStore dataStore = new GitDataStore();
+            assertEquals("refs/heads/other",
+                    dataStore.resolveLocalHeadTarget(local, fetchResult, new RefSpec("+refs/heads/main:refs/heads/main"), "HEAD"));
+        } finally {
+            local.close();
+        }
+    }
+
+    // Bug fix (root cause, end-to-end): reproduces the reported failure hermetically. When the remote does not
+    // advertise HEAD, JGit's FetchProcess.isInitialBranchMissing rejects the literal "HEAD" that the pre-fix
+    // code passed to setInitialBranch, failing the fetch with the exact reported error ("Remote branch 'HEAD'
+    // not found in upstream origin"). resolveInitialBranch() maps the default commit_id to null, selecting
+    // JGit's "use the branch pointed to by HEAD" behavior, so the fetch succeeds and the crawl proceeds via
+    // the local HEAD fallback. Reverting either half of the fix fails this test.
+    @Test
+    public void test_storeData_succeedsWhenRemoteDoesNotAdvertiseHead() throws Exception {
+        final Map<String, String> files = new LinkedHashMap<>();
+        files.put("a.txt", "a");
+        final File remote = createRepoWithUnadvertisedHead("foo", files);
+
+        // Model a persistent repository_path left by a previous crawl: the repo exists and its HEAD is already
+        // linked to the branch that crawl resolved -- the state in which the reported failure occurred. HEAD is
+        // linked explicitly rather than relying on JGit's default init branch, which init.defaultBranch can change.
+        final File persistent = Files.createTempDirectory("fess-ds-git-nohead-persist-").toFile();
+        tempDirs.add(persistent);
+        final Repository seeded = FileRepositoryBuilder.create(new File(persistent, ".git"));
+        seeded.create();
+        seeded.updateRef(org.eclipse.jgit.lib.Constants.HEAD).link("refs/heads/foo");
+        seeded.close();
+
+        final DataStoreParams params = new DataStoreParams();
+        params.put("uri", remote.getAbsolutePath());
+        params.put("repository_path", persistent.getAbsolutePath());
+
+        final List<String> urlList = new ArrayList<>();
+        newCollectingDataStore(urlList).storeData(null, null, params, null, null);
+
+        assertTrue(urlList.contains("a.txt"));
     }
 
     // Bug fix (end-to-end): a re-crawl against a persistent repository_path (where the local HEAD is already
     // born) must succeed and stay incremental. This is the scenario that triggered the reported
-    // "Remote branch 'HEAD' not found in upstream origin" crash. (The local file:// transport used here
-    // always advertises HEAD, so this test guards the whole persistent re-crawl flow -- including that the
-    // resolved ref / prev_source_ref stays stable so the second run is incremental; the v2-specific
-    // mechanics a local transport cannot reproduce are covered by test_resolveInitialBranch() and
-    // test_resolveLocalHeadTarget_*.)
+    // "Remote branch 'HEAD' not found in upstream origin" crash. (This remote is an ordinary one, which the
+    // local file:// transport does advertise a HEAD for, so this test guards the whole persistent re-crawl
+    // flow -- including that the resolved ref / prev_source_ref stays stable so the second run is
+    // incremental. The failure itself, which needs a remote that advertises no HEAD, is covered by
+    // test_storeData_succeedsWhenRemoteDoesNotAdvertiseHead().)
     @Test
     public void test_storeData_persistentRepositoryRecrawl() throws Exception {
         final Map<String, String> files = new LinkedHashMap<>();


### PR DESCRIPTION
## Problem

Crawling a Git repository fails with:

```
org.eclipse.jgit.api.errors.TransportException: Remote branch 'HEAD' not found in upstream origin
```

when a persistent `repository_path` is configured and the repository is crawled a second time.

## Root cause

The default `commit_id` is the literal string `"HEAD"`, which `storeData()` passed to JGit's `FetchCommand.setInitialBranch()`. JGit validates the initial branch as a concrete branch/tag name (`FetchProcess.isInitialBranchMissing`): it throws unless the advertised refs contain `HEAD`, `refs/heads/HEAD`, or `refs/tags/HEAD`.

Under protocol v2 the remote `HEAD` is advertised only when JGit explicitly requests it, and JGit requests it only when the local `HEAD` is unborn (an initial clone into an empty repository). With a persistent `repository_path`, the first crawl leaves the local `HEAD` born, so subsequent fetches request only the refspec prefixes (`refs/heads/`) and the advertised refs no longer include `HEAD` — the validation then fails.

Fresh (non-persistent) crawls use a new temporary repository each run (unborn `HEAD`), so they are unaffected; this only surfaces on re-crawls of a persistent `repository_path`.

## Fix

- `resolveInitialBranch()`: map the default `HEAD`/blank `commit_id` to `null` — JGit's documented "use the branch pointed to by `HEAD`" sentinel — instead of the literal `"HEAD"`. An explicitly configured branch/tag is still pinned unchanged, so the non-default case behaves exactly as before.
- `resolveDefaultBranch()`: when the remote `HEAD` is not advertised on a re-crawl, fall back to the local `HEAD`'s symref target (established by the first crawl) instead of the literal `"HEAD"`. This keeps the resolved ref — and therefore `prev_source_ref` — stable across runs, so incremental crawling continues to work and no spurious full reindex is triggered.

## Compatibility

No change to which commit is crawled for any `commit_id` value (unset/`HEAD`, branch, tag, SHA). `setInitialBranch(null)` is equivalent to the previous `setInitialBranch("HEAD")` on the success path; they differ only in JGit's own fail-fast validation of the initial branch.

## Tests

- `test_resolveInitialBranch`
- `test_resolveLocalHeadTarget_symbolicHead`
- `test_resolveLocalHeadTarget_detachedHeadReturnsCommitId`
- `test_storeData_persistentRepositoryRecrawl` — two crawls against a single persistent `repository_path`; the second run (born local `HEAD`) is verified to succeed and stay incremental.
- `test_resolveDefaultBranch_fallsBackToLocalHeadWhenHeadNotAdvertised` — exercises the `headRef == null` fallback that the in-process test transport (which always advertises `HEAD`) cannot reach via `storeData`.
- `test_storeData_usesResolvedInitialBranchForFetch` — proves the resolved initial branch (not the raw `commit_id`) is passed to the fetch.

The last two fail if either wiring is reverted, so they pin the fix directly.

## Note

For the default `commit_id`, the initial branch passed to JGit is now `null` instead of the literal `"HEAD"`. As a result, JGit writes a `fetch` reflog entry for updated tracking refs (it previously suppressed it for a non-null initial branch). On a persistent `repository_path` this adds one reflog line per updated ref per crawl — negligible, and the normal behavior of a Git fetch. Temporary (non-persistent) clones are deleted after each run and are unaffected.
