### PR TITLE
feat(build): deploy to maven.codelibs.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,24 @@
 			</plugin>
 		</plugins>
 	</build>
+	<!-- Fess plugins are distributed through maven.codelibs.org instead of Maven Central.
+	     This cannot be inherited from fess-parent: distributionManagement is inherited
+	     unconditionally, so declaring it there would also redirect the SNAPSHOT
+	     deployments of fess-parent, fess, fess-crawler, fess-crawler-playwright and
+	     fess-suggest, which stay on Maven Central. The scpexe transport comes from
+	     the wagon-ssh-external build extension inherited from fess-parent. -->
+	<distributionManagement>
+		<repository>
+			<id>codelibs-repo</id>
+			<name>CodeLibs Repository</name>
+			<url>scpexe://maven.codelibs.org/var/www/maven/release</url>
+		</repository>
+		<snapshotRepository>
+			<id>codelibs-snapshots</id>
+			<name>CodeLibs Snapshot Repository</name>
+			<url>scpexe://maven.codelibs.org/var/www/maven/snapshot</url>
+		</snapshotRepository>
+	</distributionManagement>
 	<repositories>
 		<repository>
 			<id>snapshots.central.sonatype.com</id>


### PR DESCRIPTION
## Summary

Maven Central introduced an upload limit that makes it impractical to keep releasing the Fess
plugin artifacts there, so the plugins move to the CodeLibs repository. `fess-parent`, `fess`,
`fess-crawler`, `fess-crawler-playwright` and `fess-suggest` stay on Maven Central.

## Why this is declared per plugin rather than in fess-parent

`distributionManagement` is inherited unconditionally and a POM cannot exempt itself from what
it declares. Declaring the CodeLibs repositories in `fess-parent` therefore also redirected the
SNAPSHOT deployments of the five projects that stay on Maven Central, because
`central-publishing-maven-plugin` resolves SNAPSHOT deployments through
`project.getDistributionManagementArtifactRepository()` and only falls back to
`centralSnapshotsUrl` when it is absent. See codelibs/fess-parent#62.

## Why scpexe rather than scp

The transport comes from the `wagon-ssh-external` build extension inherited from
`fess-parent`, which delegates to the platform SSH client. The embedded alternative,
`wagon-ssh`, depends on `com.jcraft:jsch` 0.1.55 — the final release of that project — whose
only key types are DSA, ECDSA, RSA and PKCS8; an ed25519 key, or any key stored in the OpenSSH
key file format, is rejected with `invalid privatekey` before a connection is even attempted.
With `scpexe://`, key handling follows the local OpenSSH configuration, so ed25519 keys,
ssh-agent and `~/.ssh/config` all work. See codelibs/fess-parent#64.

## Verification

- `project.distributionManagement.snapshotRepository.url` resolves to the `scpexe://` URL
- `mvn validate` does not log `Installing Central Publishing features`, i.e. the Central
  Publishing lifecycle participant stays inactive and `maven-deploy-plugin` keeps its
  `default-deploy` execution
- `mvn deploy` runs `maven-deploy-plugin:3.1.4:deploy` and hands the transfer to the platform
  SSH client, so the transport resolves and key handling is out of the way. The transfer itself
  was not completed, because the verification environment has no route to the repository host.

## Depends on

- codelibs/fess-parent#62
- codelibs/fess-parent#64 — must be merged first, otherwise deployment fails with
  `Unsupported transport protocol scpexe`

## Note for whoever runs the deployment

`settings.xml` needs `codelibs-repo` / `codelibs-snapshots` server entries.
